### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -1,5 +1,8 @@
 name: Deploy on release
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [published]


### PR DESCRIPTION
Potential fix for [https://github.com/WxboySuper/Santa_Tracker/security/code-scanning/29](https://github.com/WxboySuper/Santa_Tracker/security/code-scanning/29)

To fix this issue, you should explicitly set a `permissions` block in your workflow file, limiting the scope of the GITHUB_TOKEN used by the job. Because this workflow does not appear to use the GITHUB_TOKEN to interact with repository contents or to write resources on GitHub (e.g., releases, issues, PRs), you can safely assign `contents: read` as the minimal necessary permission. This can be done by adding the `permissions:` key at the root of the workflow (immediately below the `name:` and before or after `on:`). No new methods, imports, or code logic are necessary, only a YAML edit to add the block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
