### PR TITLE
chore(codeql/codescene): exclude generated archives and lockfiles

### DIFF
--- a/.codescene
+++ b/.codescene
@@ -4,4 +4,5 @@ exclude:
   - pnpm-lock.yaml
   - apps/web/package-lock.json
   - apps/web/public/**
+  - apps/web/data/**
   - Route Data/**

--- a/.codescene
+++ b/.codescene
@@ -1,0 +1,7 @@
+# CodeScene - ignore generated and archive files
+exclude:
+  - archive/**
+  - pnpm-lock.yaml
+  - apps/web/package-lock.json
+  - apps/web/public/**
+  - Route Data/**

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,7 @@
+name: "CodeQL config"
+paths-ignore:
+  - archive/**
+  - apps/web/public/**
+  - apps/web/data/**
+  - pnpm-lock.yaml
+  - apps/web/package-lock.json

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,5 +3,6 @@ paths-ignore:
   - archive/**
   - apps/web/public/**
   - apps/web/data/**
+  - Route Data/**
   - pnpm-lock.yaml
   - apps/web/package-lock.json


### PR DESCRIPTION
Config-only follow-up for analyzer hygiene.

Adds matching CodeScene and CodeQL exclusions for generated and archive content:

- archive/**
- pnpm-lock.yaml
- apps/web/package-lock.json
- apps/web/public/**
- apps/web/data/**
- Route Data/**

No runtime code changes are included. The workspace foundation is already on main via #350.

Related to #221.

Disclosure: This PR description was generated by gpt-5.6-luna using the Codex harness within T3 Code. It is not written by Alex.