### PR TITLE
ci: add OpenCode workflow from GFC

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,173 @@
+name: Review | OpenCode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  classify-request:
+    if: |
+      github.event.comment.user.login == 'WxboySuper' &&
+      (github.event.comment.body == '/oc' ||
+       github.event.comment.body == '/opencode' ||
+       startsWith(github.event.comment.body, '/oc ') ||
+       startsWith(github.event.comment.body, '/opencode '))
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      mode: ${{ steps.classify.outputs.result }}
+      branch: ${{ steps.classify.outputs.branch }}
+    steps:
+      - id: classify
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          result-encoding: string
+          script: |
+            const pullNumber = context.payload.pull_request?.number ??
+              (context.payload.issue?.pull_request ? context.payload.issue.number : undefined)
+            if (pullNumber) {
+              const { data: pull } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pullNumber,
+              })
+              const head = pull.head.repo
+              core.setOutput('branch', pull.head.ref)
+              return head?.full_name === `${context.repo.owner}/${context.repo.repo}` && !head.fork
+                ? 'trusted-pr'
+                : 'blocked'
+            }
+
+            core.setOutput('branch', '')
+            return context.payload.issue?.user?.login === 'WxboySuper'
+              ? 'trusted-issue'
+              : 'triage-issue'
+
+  opencode-write:
+    needs: classify-request
+    if: needs.classify-request.outputs.mode == 'trusted-pr' || needs.classify-request.outputs.mode == 'trusted-issue'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ needs.classify-request.outputs.branch || github.sha }}
+          persist-credentials: true
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Require trusted workflow push credential
+        if: needs.classify-request.outputs.mode == 'trusted-pr'
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          if [[ -z "$GH_PAT" ]]; then
+            echo "GH_PAT is required before OpenCode can safely update workflow files."
+            exit 1
+          fi
+
+      - name: Record trusted PR branch tip
+        if: needs.classify-request.outputs.mode == 'trusted-pr'
+        env:
+          PR_BRANCH: ${{ needs.classify-request.outputs.branch }}
+        run: |
+          git fetch origin "$PR_BRANCH"
+          expected_sha="$(git rev-parse FETCH_HEAD)"
+          start_sha="$(git rev-parse HEAD)"
+          if [[ "$start_sha" != "$expected_sha" ]]; then
+            echo "Refusing recovery because the checked-out commit is not the PR branch tip."
+            exit 1
+          fi
+
+          printf 'OPENCODE_FORCE_PUSH_BRANCH=%s\n' "$PR_BRANCH" >> "$GITHUB_ENV"
+          printf 'OPENCODE_FORCE_PUSH_EXPECTED_SHA=%s\n' "$expected_sha" >> "$GITHUB_ENV"
+          printf 'OPENCODE_FORCE_PUSH_START_SHA=%s\n' "$start_sha" >> "$GITHUB_ENV"
+
+      - name: Run opencode
+        id: run-opencode
+        continue-on-error: true
+        uses: anomalyco/opencode/github@a3b97d9090ccf4aa9ac32268486283e3131e36b4 # fix(github): enforce existing git author identity
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode/muse-spark-1.2-contributor-free
+          use_github_token: true
+          mentions: /oc,/opencode
+
+      - name: Push a rebased trusted PR
+        id: push-rebased-pr
+        if: always() && needs.classify-request.outputs.mode == 'trusted-pr'
+        env:
+          PR_BRANCH: ${{ needs.classify-request.outputs.branch }}
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+          remote_ref="refs/heads/$PR_BRANCH"
+          local_sha="$(git rev-parse HEAD)"
+          remote_sha="$(git ls-remote origin "$remote_ref" | awk '{print $1}')"
+
+          if [[ "$remote_sha" == "$local_sha" ]]; then
+            echo "OpenCode already pushed this commit."
+            exit 0
+          fi
+
+          if [[ "$local_sha" == "$OPENCODE_FORCE_PUSH_START_SHA" ]]; then
+            echo "OpenCode did not create a commit to recover."
+            exit 0
+          fi
+
+          if [[ "$remote_sha" != "$OPENCODE_FORCE_PUSH_EXPECTED_SHA" ]]; then
+            echo "Refusing to overwrite $PR_BRANCH because it changed during the OpenCode run."
+            exit 1
+          fi
+
+          git config --local --replace-all http.https://github.com/.extraheader \
+            "AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_PAT" | base64 -w 0)"
+          git push \
+            "--force-with-lease=$remote_ref:$OPENCODE_FORCE_PUSH_EXPECTED_SHA" \
+            origin "HEAD:$remote_ref"
+          echo "recovered=true" >> "$GITHUB_OUTPUT"
+
+      - name: Fail unrecovered OpenCode errors
+        if: steps.run-opencode.outcome == 'failure' && steps.push-rebased-pr.outputs.recovered != 'true'
+        run: |
+          echo "OpenCode failed before its rewritten branch could be safely pushed."
+          exit 1
+
+  opencode-triage:
+    needs: classify-request
+    if: needs.classify-request.outputs.mode == 'triage-issue'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run opencode triage
+        uses: anomalyco/opencode/github@a3b97d9090ccf4aa9ac32268486283e3131e36b4 # fix(github): enforce existing git author identity
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode/deepseek-v4-flash-free
+          use_github_token: true
+          mentions: /oc,/opencode
+          prompt: >-
+            Triage this issue. Do not edit repository files, create branches or pull requests,
+            commit, or push. Reply with a concise assessment, reproduction questions, labels, and
+            recommended next steps.


### PR DESCRIPTION
Port \.github/workflows/opencode.yml\ from \WxboySuper/Graphical-Forecast-Creator\ (\origin/main\) to enable \\/oc\ and \\/opencode\ automation.

**Source:** \Graphical-Forecast-Creator:.github/workflows/opencode.yml\ @ \origin/main\ (model \opencode/muse-spark-1.2-contributor-free\ for writes, \opencode/deepseek-v4-flash-free\ for triage).

- Trusted-PR write path with \GH_PAT\ force-with-lease recovery for rebased pushes
- Triage path for non-PR \\/oc\ invocations (read-only reply)
- Restricted to \WxboySuper\ and \\/oc\/\/opencode\ mentions

Workflow is an exact copy (pinned SHAs: \ctions/checkout@34e1148\, \ctions/github-script@f28e40c\, \nomalyco/opencode/github@a3b97d9\).

Fast-track: CI-only change, no runtime code.