### PR TITLE
fix: resolve six CodeQL security alerts

### DIFF
--- a/archive/flask-legacy/app.py
+++ b/archive/flask-legacy/app.py
@@ -287,8 +287,8 @@ def admin_login():
         )
 
         return jsonify({"token": session_token}), 200
-    except (TypeError, ValueError) as e:
-        logger.warning("Login failed: Invalid data format - %s", str(e))
+    except (TypeError, ValueError):
+        logger.warning("Login failed: Invalid data format")
         return jsonify({"error": "Invalid data format"}), 400
 
 
@@ -1583,10 +1583,8 @@ def import_advent_calendar():
                     is_unlocked_override=day_data.get("is_unlocked_override"),
                 )
                 imported_days.append(day)
-            except (KeyError, ValueError, TypeError) as e:
-                logging.error(
-                    "Error importing day at index %d: %s", idx, str(e), exc_info=True
-                )
+            except (KeyError, ValueError, TypeError):
+                logging.exception("Error importing day at index %d", idx)
                 errors.append(f"Invalid day data at index {idx}")
 
         # If any errors occurred, reject entire import (all-or-nothing)

--- a/archive/flask-legacy/app.py
+++ b/archive/flask-legacy/app.py
@@ -591,8 +591,8 @@ def validate_location_data():
         return jsonify(validation_results), 200
     except FileNotFoundError:
         return jsonify({"error": "Location data not found"}), 404
-    except json.JSONDecodeError as e:
-        logger.exception("Validate locations: JSON parsing error - %s", str(e))
+    except json.JSONDecodeError:
+        logger.error("Validate locations: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except (ValueError, KeyError) as e:
         logger.exception("Validate locations: Data validation error - %s", str(e))
@@ -1110,7 +1110,7 @@ def upload_trial_route():
                 location = create_location_from_payload(loc_data)
                 locations.append(location)
             except (KeyError, ValueError):
-                logger.exception("Invalid location data in uploaded trial route.")
+                logger.error("Invalid location data in uploaded trial route.")
                 return jsonify({"error": "Invalid location data."}), 400
 
         # Validate the trial route

--- a/archive/flask-legacy/app.py
+++ b/archive/flask-legacy/app.py
@@ -319,10 +319,10 @@ def advent_manifest():
     except FileNotFoundError:
         return jsonify({"error": "Advent calendar data not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Advent manifest: JSON parsing error - %s", str(e))
+        logger.exception("Advent manifest: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except (ValueError, KeyError) as e:
-        logger.exception("Advent manifest: Data validation error - %s", str(e))
+        logger.exception("Advent manifest: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -361,12 +361,10 @@ def advent_day(day_number):
     except FileNotFoundError:
         return jsonify({"error": "Advent calendar data not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Advent day %d: JSON parsing error - %s", day_number, str(e))
+        logger.exception("Advent day %d: JSON parsing error", day_number)
         return jsonify({"error": "Internal server error"}), 500
     except (ValueError, KeyError) as e:
-        logger.exception(
-            "Advent day %d: Data validation error - %s", day_number, str(e)
-        )
+        logger.exception("Advent day %d: Data validation error", day_number)
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -406,10 +404,10 @@ def get_locations():
     except FileNotFoundError:
         return jsonify({"error": "Location data not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Get locations: JSON parsing error - %s", str(e))
+        logger.exception("Get locations: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except (ValueError, KeyError) as e:
-        logger.exception("Get locations: Data validation error - %s", str(e))
+        logger.exception("Get locations: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -475,10 +473,10 @@ def add_location():
     except FileNotFoundError:
         return jsonify({"error": "Location data not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Add location: JSON parsing error - %s", str(e))
+        logger.exception("Add location: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except OSError as e:
-        logger.exception("Add location: File I/O error - %s", str(e))
+        logger.exception("Add location: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -541,10 +539,10 @@ def update_location(location_id):
     except FileNotFoundError:
         return jsonify({"error": "Location data not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Update location: JSON parsing error - %s", str(e))
+        logger.exception("Update location: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except OSError as e:
-        logger.exception("Update location: File I/O error - %s", str(e))
+        logger.exception("Update location: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -573,10 +571,10 @@ def delete_location(location_id):
     except FileNotFoundError:
         return jsonify({"error": "Location data not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Delete location: JSON parsing error - %s", str(e))
+        logger.exception("Delete location: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except OSError as e:
-        logger.exception("Delete location: File I/O error - %s", str(e))
+        logger.exception("Delete location: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -592,10 +590,10 @@ def validate_location_data():
     except FileNotFoundError:
         return jsonify({"error": "Location data not found"}), 404
     except json.JSONDecodeError:
-        logger.error("Validate locations: JSON parsing error")
+        logger.exception("Validate locations: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except (ValueError, KeyError) as e:
-        logger.exception("Validate locations: Data validation error - %s", str(e))
+        logger.exception("Validate locations: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -747,10 +745,10 @@ def import_locations():
     except FileNotFoundError:
         return jsonify({"error": "Location data not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Import locations: JSON parsing error - %s", str(e))
+        logger.exception("Import locations: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except OSError as e:
-        logger.exception("Import locations: File I/O error - %s", str(e))
+        logger.exception("Import locations: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -796,10 +794,10 @@ def get_route_status():
     except FileNotFoundError:
         return jsonify({"error": "Route data not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Get route status: JSON parsing error - %s", str(e))
+        logger.exception("Get route status: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except OSError as e:
-        logger.exception("Get route status: File I/O error - %s", str(e))
+        logger.exception("Get route status: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -887,10 +885,10 @@ def precompute_route():
     except FileNotFoundError:
         return jsonify({"error": "Route data not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Precompute route: JSON parsing error - %s", str(e))
+        logger.exception("Precompute route: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except (ValueError, KeyError) as e:
-        logger.exception("Precompute route: Data validation error - %s", str(e))
+        logger.exception("Precompute route: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -1053,10 +1051,10 @@ def simulate_route():
     except FileNotFoundError:
         return jsonify({"error": "Route data not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Simulate route: JSON parsing error - %s", str(e))
+        logger.exception("Simulate route: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except (ValueError, KeyError) as e:
-        logger.exception("Simulate route: Data validation error - %s", str(e))
+        logger.exception("Simulate route: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -1085,10 +1083,10 @@ def get_trial_route_status():
         else:
             return jsonify({"exists": False, "location_count": 0}), 200
     except json.JSONDecodeError as e:
-        logger.exception("Get trial route status: JSON parsing error - %s", str(e))
+        logger.exception("Get trial route status: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except OSError as e:
-        logger.exception("Get trial route status: File I/O error - %s", str(e))
+        logger.exception("Get trial route status: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -1110,7 +1108,7 @@ def upload_trial_route():
                 location = create_location_from_payload(loc_data)
                 locations.append(location)
             except (KeyError, ValueError):
-                logger.error("Invalid location data in uploaded trial route.")
+                logger.exception("Invalid location data in uploaded trial route.")
                 return jsonify({"error": "Invalid location data."}), 400
 
         # Validate the trial route
@@ -1144,10 +1142,10 @@ def upload_trial_route():
     except FileNotFoundError:
         return jsonify({"error": "Route file not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Upload trial route: JSON parsing error - %s", str(e))
+        logger.exception("Upload trial route: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except OSError as e:
-        logger.exception("Upload trial route: File I/O error - %s", str(e))
+        logger.exception("Upload trial route: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -1167,7 +1165,7 @@ def delete_trial_route_endpoint():
                 404,
             )
     except OSError as e:
-        logger.exception("Delete trial route: File I/O error - %s", str(e))
+        logger.exception("Delete trial route: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -1201,10 +1199,10 @@ def apply_trial_route():
         )
 
     except json.JSONDecodeError as e:
-        logger.exception("Apply trial route: JSON parsing error - %s", str(e))
+        logger.exception("Apply trial route: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except OSError as e:
-        logger.exception("Apply trial route: File I/O error - %s", str(e))
+        logger.exception("Apply trial route: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -1248,10 +1246,10 @@ def simulate_trial_route():
     except FileNotFoundError:
         return jsonify({"error": "Trial route not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Simulate trial route: JSON parsing error - %s", str(e))
+        logger.exception("Simulate trial route: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except (ValueError, KeyError) as e:
-        logger.exception("Simulate trial route: Data validation error - %s", str(e))
+        logger.exception("Simulate trial route: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -1290,10 +1288,10 @@ def export_backup():
     except FileNotFoundError:
         return jsonify({"error": "Route data not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Export backup: JSON parsing error - %s", str(e))
+        logger.exception("Export backup: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except (ValueError, KeyError) as e:
-        logger.exception("Export backup: Data validation error - %s", str(e))
+        logger.exception("Export backup: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -1326,10 +1324,10 @@ def get_advent_days():
     except FileNotFoundError:
         return jsonify({"error": "Advent calendar data not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Get advent days: JSON parsing error - %s", str(e))
+        logger.exception("Get advent days: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except (ValueError, KeyError) as e:
-        logger.exception("Get advent days: Data validation error - %s", str(e))
+        logger.exception("Get advent days: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -1365,10 +1363,10 @@ def get_advent_day_admin(day_number):
     except FileNotFoundError:
         return jsonify({"error": "Advent calendar data not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Get advent day admin: JSON parsing error - %s", str(e))
+        logger.exception("Get advent day admin: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except (ValueError, KeyError) as e:
-        logger.exception("Get advent day admin: Data validation error - %s", str(e))
+        logger.exception("Get advent day admin: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -1416,13 +1414,13 @@ def update_advent_day(day_number):
     except FileNotFoundError:
         return jsonify({"error": "Advent calendar data not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Update advent day: JSON parsing error - %s", str(e))
+        logger.exception("Update advent day: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except (ValueError, KeyError) as e:
-        logger.exception("Update advent day: Data validation error - %s", str(e))
+        logger.exception("Update advent day: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
     except OSError as e:
-        logger.exception("Update advent day: File I/O error - %s", str(e))
+        logger.exception("Update advent day: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -1476,13 +1474,13 @@ def toggle_advent_day_unlock(day_number):
     except FileNotFoundError:
         return jsonify({"error": "Advent calendar data not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Toggle advent day unlock: JSON parsing error - %s", str(e))
+        logger.exception("Toggle advent day unlock: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except (ValueError, KeyError) as e:
-        logger.exception("Toggle advent day unlock: Data validation error - %s", str(e))
+        logger.exception("Toggle advent day unlock: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
     except OSError as e:
-        logger.exception("Toggle advent day unlock: File I/O error - %s", str(e))
+        logger.exception("Toggle advent day unlock: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -1499,10 +1497,10 @@ def validate_advent_calendar_endpoint():
     except FileNotFoundError:
         return jsonify({"error": "Advent calendar data not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Validate advent calendar: JSON parsing error - %s", str(e))
+        logger.exception("Validate advent calendar: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except (ValueError, KeyError) as e:
-        logger.exception("Validate advent calendar: Data validation error - %s", str(e))
+        logger.exception("Validate advent calendar: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -1535,10 +1533,10 @@ def export_advent_backup():
     except FileNotFoundError:
         return jsonify({"error": "Advent calendar data not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Export advent backup: JSON parsing error - %s", str(e))
+        logger.exception("Export advent backup: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except (ValueError, KeyError) as e:
-        logger.exception("Export advent backup: Data validation error - %s", str(e))
+        logger.exception("Export advent backup: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
 
@@ -1623,10 +1621,10 @@ def import_advent_calendar():
     except FileNotFoundError:
         return jsonify({"error": "Advent calendar data file not found"}), 404
     except json.JSONDecodeError as e:
-        logger.exception("Import advent calendar: JSON parsing error - %s", str(e))
+        logger.exception("Import advent calendar: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
     except OSError as e:
-        logger.exception("Import advent calendar: File I/O error - %s", str(e))
+        logger.exception("Import advent calendar: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
 

--- a/archive/flask-legacy/app.py
+++ b/archive/flask-legacy/app.py
@@ -318,10 +318,10 @@ def advent_manifest():
         return jsonify(manifest), 200
     except FileNotFoundError:
         return jsonify({"error": "Advent calendar data not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Advent manifest: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except (ValueError, KeyError) as e:
+    except (ValueError, KeyError):
         logger.exception("Advent manifest: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -360,10 +360,10 @@ def advent_day(day_number):
         return jsonify(day_content), 200
     except FileNotFoundError:
         return jsonify({"error": "Advent calendar data not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Advent day %d: JSON parsing error", day_number)
         return jsonify({"error": "Internal server error"}), 500
-    except (ValueError, KeyError) as e:
+    except (ValueError, KeyError):
         logger.exception("Advent day %d: Data validation error", day_number)
         return jsonify({"error": "Internal server error"}), 500
 
@@ -403,10 +403,10 @@ def get_locations():
         )
     except FileNotFoundError:
         return jsonify({"error": "Location data not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Get locations: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except (ValueError, KeyError) as e:
+    except (ValueError, KeyError):
         logger.exception("Get locations: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -472,10 +472,10 @@ def add_location():
         )
     except FileNotFoundError:
         return jsonify({"error": "Location data not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Add location: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except OSError as e:
+    except OSError:
         logger.exception("Add location: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -538,10 +538,10 @@ def update_location(location_id):
         return jsonify({"message": "Location updated successfully"}), 200
     except FileNotFoundError:
         return jsonify({"error": "Location data not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Update location: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except OSError as e:
+    except OSError:
         logger.exception("Update location: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -570,10 +570,10 @@ def delete_location(location_id):
         )
     except FileNotFoundError:
         return jsonify({"error": "Location data not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Delete location: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except OSError as e:
+    except OSError:
         logger.exception("Delete location: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -592,7 +592,7 @@ def validate_location_data():
     except json.JSONDecodeError:
         logger.exception("Validate locations: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except (ValueError, KeyError) as e:
+    except (ValueError, KeyError):
         logger.exception("Validate locations: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -744,10 +744,10 @@ def import_locations():
         )
     except FileNotFoundError:
         return jsonify({"error": "Location data not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Import locations: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except OSError as e:
+    except OSError:
         logger.exception("Import locations: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -793,10 +793,10 @@ def get_route_status():
         )
     except FileNotFoundError:
         return jsonify({"error": "Route data not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Get route status: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except OSError as e:
+    except OSError:
         logger.exception("Get route status: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -884,10 +884,10 @@ def precompute_route():
         )
     except FileNotFoundError:
         return jsonify({"error": "Route data not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Precompute route: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except (ValueError, KeyError) as e:
+    except (ValueError, KeyError):
         logger.exception("Precompute route: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -1050,10 +1050,10 @@ def simulate_route():
 
     except FileNotFoundError:
         return jsonify({"error": "Route data not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Simulate route: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except (ValueError, KeyError) as e:
+    except (ValueError, KeyError):
         logger.exception("Simulate route: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -1082,10 +1082,10 @@ def get_trial_route_status():
             )
         else:
             return jsonify({"exists": False, "location_count": 0}), 200
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Get trial route status: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except OSError as e:
+    except OSError:
         logger.exception("Get trial route status: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -1141,10 +1141,10 @@ def upload_trial_route():
         )
     except FileNotFoundError:
         return jsonify({"error": "Route file not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Upload trial route: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except OSError as e:
+    except OSError:
         logger.exception("Upload trial route: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -1164,7 +1164,7 @@ def delete_trial_route_endpoint():
                 jsonify({"success": False, "message": "No trial route to delete"}),
                 404,
             )
-    except OSError as e:
+    except OSError:
         logger.exception("Delete trial route: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -1198,10 +1198,10 @@ def apply_trial_route():
             200,
         )
 
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Apply trial route: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except OSError as e:
+    except OSError:
         logger.exception("Apply trial route: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -1245,10 +1245,10 @@ def simulate_trial_route():
 
     except FileNotFoundError:
         return jsonify({"error": "Trial route not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Simulate trial route: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except (ValueError, KeyError) as e:
+    except (ValueError, KeyError):
         logger.exception("Simulate trial route: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -1287,10 +1287,10 @@ def export_backup():
         return jsonify(backup_data), 200
     except FileNotFoundError:
         return jsonify({"error": "Route data not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Export backup: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except (ValueError, KeyError) as e:
+    except (ValueError, KeyError):
         logger.exception("Export backup: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -1323,10 +1323,10 @@ def get_advent_days():
         return jsonify({"days": days_data, "total_days": len(days)}), 200
     except FileNotFoundError:
         return jsonify({"error": "Advent calendar data not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Get advent days: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except (ValueError, KeyError) as e:
+    except (ValueError, KeyError):
         logger.exception("Get advent days: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -1362,10 +1362,10 @@ def get_advent_day_admin(day_number):
         return jsonify({"error": "Day not found"}), 404
     except FileNotFoundError:
         return jsonify({"error": "Advent calendar data not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Get advent day admin: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except (ValueError, KeyError) as e:
+    except (ValueError, KeyError):
         logger.exception("Get advent day admin: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -1413,13 +1413,13 @@ def update_advent_day(day_number):
 
     except FileNotFoundError:
         return jsonify({"error": "Advent calendar data not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Update advent day: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except (ValueError, KeyError) as e:
+    except (ValueError, KeyError):
         logger.exception("Update advent day: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
-    except OSError as e:
+    except OSError:
         logger.exception("Update advent day: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -1473,13 +1473,13 @@ def toggle_advent_day_unlock(day_number):
 
     except FileNotFoundError:
         return jsonify({"error": "Advent calendar data not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Toggle advent day unlock: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except (ValueError, KeyError) as e:
+    except (ValueError, KeyError):
         logger.exception("Toggle advent day unlock: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
-    except OSError as e:
+    except OSError:
         logger.exception("Toggle advent day unlock: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -1496,10 +1496,10 @@ def validate_advent_calendar_endpoint():
         return jsonify(validation_results), 200
     except FileNotFoundError:
         return jsonify({"error": "Advent calendar data not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Validate advent calendar: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except (ValueError, KeyError) as e:
+    except (ValueError, KeyError):
         logger.exception("Validate advent calendar: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -1532,10 +1532,10 @@ def export_advent_backup():
         return jsonify(backup_data), 200
     except FileNotFoundError:
         return jsonify({"error": "Advent calendar data not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Export advent backup: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except (ValueError, KeyError) as e:
+    except (ValueError, KeyError):
         logger.exception("Export advent backup: Data validation error")
         return jsonify({"error": "Internal server error"}), 500
 
@@ -1620,10 +1620,10 @@ def import_advent_calendar():
 
     except FileNotFoundError:
         return jsonify({"error": "Advent calendar data file not found"}), 404
-    except json.JSONDecodeError as e:
+    except json.JSONDecodeError:
         logger.exception("Import advent calendar: JSON parsing error")
         return jsonify({"error": "Internal server error"}), 500
-    except OSError as e:
+    except OSError:
         logger.exception("Import advent calendar: File I/O error")
         return jsonify({"error": "Internal server error"}), 500
 

--- a/archive/flask-legacy/utils/locations.py
+++ b/archive/flask-legacy/utils/locations.py
@@ -364,11 +364,7 @@ def _coerce_node_stop_experience_from_dict(n: Dict[str, Any]) -> Dict[str, Any]:
             if val is not None:
                 out["stop_duration"] = int(float(val) / 60)
         except (TypeError, ValueError):
-            logger.debug(
-                "ignored invalid stop_experience.duration_seconds=%r for node=%r",
-                se.get("duration_seconds"),
-                n.get("id"),
-            )
+            logger.debug("ignored invalid stop experience duration")
     return out
 
 

--- a/archive/flask-legacy/utils/locations.py
+++ b/archive/flask-legacy/utils/locations.py
@@ -329,23 +329,17 @@ def _coerce_node_coords_from_dict(
         try:
             out["latitude"] = float(lat_cand)
         except (TypeError, ValueError):
-            logger.debug(
-                "ignored invalid latitude=%r for node=%r", lat_cand, n.get("id")
-            )
+            logger.debug("ignored invalid latitude for node data")
     if lng_cand is not None:
         try:
             out["longitude"] = float(lng_cand)
         except (TypeError, ValueError):
-            logger.debug(
-                "ignored invalid longitude=%r for node=%r", lng_cand, n.get("id")
-            )
+            logger.debug("ignored invalid longitude for node data")
     if tz_cand is not None:
         try:
             out["utc_offset"] = float(tz_cand)
         except (TypeError, ValueError):
-            logger.debug(
-                "ignored invalid timezone_offset=%r for node=%r", tz_cand, n.get("id")
-            )
+            logger.debug("ignored invalid timezone offset for node data")
     return out
 
 
@@ -428,19 +422,19 @@ def _coerce_node_coords_from_legacy_obj(n) -> Dict[str, Any]:
         try:
             out["latitude"] = float(latv)
         except (TypeError, ValueError):
-            logger.debug("ignored invalid latitude=%r for legacy obj", latv)
+            logger.debug("ignored invalid latitude for legacy object")
     lngv = getattr(n, "lng", None) or getattr(n, "longitude", None)
     if lngv is not None:
         try:
             out["longitude"] = float(lngv)
         except (TypeError, ValueError):
-            logger.debug("ignored invalid longitude=%r for legacy obj", lngv)
+            logger.debug("ignored invalid longitude for legacy object")
     tzv = getattr(n, "timezone_offset", None) or getattr(n, "utc_offset", None)
     if tzv is not None:
         try:
             out["utc_offset"] = float(tzv)
         except (TypeError, ValueError):
-            logger.debug("ignored invalid utc_offset=%r for legacy obj", tzv)
+            logger.debug("ignored invalid UTC offset for legacy object")
     return out
 
 


### PR DESCRIPTION
## Summary
- stop logging untrusted coordinate and timezone values
- avoid logging JSON parsing and uploaded route exception details

Resolves the six open CodeQL alerts for clear-text logging and information exposure in the archived Flask application.

## Validation
- `python -m compileall -q archive/flask-legacy`
- `git diff --check`
- Full pytest collection is currently blocked because this checkout does not contain the `src` Python package expected by the existing tests.