### PR TITLE
feat(contracts): define shared public IDs and versioned schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog — per-PR exhaustive (enforced in CI)
 
+## [Unreleased] — Shared public contracts (#211)
+
+- Added validated public ID schemas and constructors for locations, publications, snapshots, and activities.
+- Added versioned route and snapshot contracts with publication metadata, checksums, timestamps, and typed version errors.
+- Added deterministic snapshot metadata and consumed the fixture from the web contract test.
+
 ## [Unreleased] — Flask retirement #221
 
 ### Foundation — retire Flask runtime after parity acceptance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added validated public ID schemas and constructors for locations, publications, snapshots, and activities.
 - Added versioned route and snapshot contracts with publication metadata, checksums, timestamps, and typed version errors.
 - Added deterministic snapshot metadata and consumed the fixture from the web contract test.
+- Breaking contract change: snapshots now require `snapshotId`, `author`, and `validationReport`; old snapshot payloads must be republished with the current schema version.
 
 ## [Unreleased] — Flask retirement #221
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@santa-tracker/test-fixtures": "workspace:*",
     "@types/node": "^22.10.7",
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.4",

--- a/apps/web/src/lib/__tests__/contracts.test.ts
+++ b/apps/web/src/lib/__tests__/contracts.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { SnapshotSchema } from "@santa-tracker/contracts";
+import { createDeterministicSnapshot } from "@santa-tracker/test-fixtures";
+
+describe("server contracts", () => {
+  it("accepts the deterministic published snapshot fixture", () => {
+    expect(SnapshotSchema.safeParse(createDeterministicSnapshot()).success).toBe(true);
+  });
+});

--- a/apps/web/src/lib/__tests__/parity.test.ts
+++ b/apps/web/src/lib/__tests__/parity.test.ts
@@ -3,8 +3,6 @@ import { validateLocations, createLocationFromPayload } from "../locations";
 import { buildSimulatedFromLocations } from "../route-sim";
 import { isUnlocked, toDict, validateAdventCalendar, type AdventDay } from "../advent";
 import { createAdminToken, verifyAdminToken, verifyAdminPassword } from "../auth";
-import { SnapshotSchema } from "@santa-tracker/contracts";
-import { createDeterministicSnapshot } from "@santa-tracker/test-fixtures";
 import fs from "fs";
 import path from "path";
 
@@ -81,10 +79,6 @@ describe("Auth parity - Flask password fallback removed", () => {
 });
 
 describe("No Flask in production paths", () => {
-  it("uses the shared snapshot fixture contract", () => {
-    expect(SnapshotSchema.safeParse(createDeterministicSnapshot()).success).toBe(true);
-  });
-
   it("does not import Flask in any app file", () => {
     const files = [
       "apps/web/src/lib/auth.ts",

--- a/apps/web/src/lib/__tests__/parity.test.ts
+++ b/apps/web/src/lib/__tests__/parity.test.ts
@@ -3,6 +3,8 @@ import { validateLocations, createLocationFromPayload } from "../locations";
 import { buildSimulatedFromLocations } from "../route-sim";
 import { isUnlocked, toDict, validateAdventCalendar, type AdventDay } from "../advent";
 import { createAdminToken, verifyAdminToken, verifyAdminPassword } from "../auth";
+import { SnapshotSchema } from "@santa-tracker/contracts";
+import { createDeterministicSnapshot } from "@santa-tracker/test-fixtures";
 import fs from "fs";
 import path from "path";
 
@@ -79,6 +81,10 @@ describe("Auth parity - Flask password fallback removed", () => {
 });
 
 describe("No Flask in production paths", () => {
+  it("uses the shared snapshot fixture contract", () => {
+    expect(SnapshotSchema.safeParse(createDeterministicSnapshot()).success).toBe(true);
+  });
+
   it("does not import Flask in any app file", () => {
     const files = [
       "apps/web/src/lib/auth.ts",

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -84,6 +84,14 @@ Data writes use temporary files and rename them into place. Each write also reco
 - `packages/config` contains typed configuration.
 - `archive/flask-legacy` contains the retired Flask source and its maintenance-only checks.
 
+### Public contract changes
+
+`@santa-tracker/contracts` validates public route, snapshot, ID, and activity payloads. The current schema version is `2026.0.0`.
+
+Snapshots require `snapshotId`, `author`, and `validationReport`. This is a breaking change for older snapshot files. Republish those files with the current version before serving them.
+
+Use `parseRoute` and `parseSnapshot` at trust boundaries. Unsupported versions throw `ContractValidationError` with code `unsupported_schema_version`; malformed payloads use `invalid_input`.
+
 Do not add runtime dependencies on files under `archive/`.
 
 ## Continuous integration

--- a/packages/contracts/src/ids.ts
+++ b/packages/contracts/src/ids.ts
@@ -4,18 +4,36 @@
  */
 
 export const SCHEMA_VERSION = '2026.0.0' as const;
+export const SUPPORTED_SCHEMA_VERSIONS = [SCHEMA_VERSION] as const;
 
-export type PublicationId = string & { readonly brand: unique symbol };
-export type LocationId = string & { readonly brand: unique symbol };
-export type SnapshotId = string & { readonly brand: unique symbol };
-export type ActivityId = string & { readonly brand: unique symbol };
+const PUBLIC_ID_PATTERN = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/;
+
+export type PublicationId = string & { readonly brand: 'PublicationId' };
+export type LocationId = string & { readonly brand: 'LocationId' };
+export type SnapshotId = string & { readonly brand: 'SnapshotId' };
+export type ActivityId = string & { readonly brand: 'ActivityId' };
 
 export function createPublicationId(value: string): PublicationId {
-  return value as PublicationId;
+  return createPublicId(value, 'publication') as PublicationId;
 }
 
 export function createLocationId(value: string): LocationId {
-  return value as LocationId;
+  return createPublicId(value, 'location') as LocationId;
+}
+
+export function createSnapshotId(value: string): SnapshotId {
+  return createPublicId(value, 'snapshot') as SnapshotId;
+}
+
+export function createActivityId(value: string): ActivityId {
+  return createPublicId(value, 'activity') as ActivityId;
+}
+
+function createPublicId(value: string, kind: string): string {
+  if (!PUBLIC_ID_PATTERN.test(value)) {
+    throw new TypeError(`Invalid ${kind} identifier: ${value}`);
+  }
+  return value;
 }
 
 export const SeasonModeValues = [

--- a/packages/contracts/src/ids.ts
+++ b/packages/contracts/src/ids.ts
@@ -6,7 +6,15 @@
 export const SCHEMA_VERSION = '2026.0.0' as const;
 export const SUPPORTED_SCHEMA_VERSIONS = [SCHEMA_VERSION] as const;
 
-const PUBLIC_ID_PATTERN = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/;
+export const PUBLIC_ID_PATTERN = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/;
+
+export class InvalidPublicIdError extends TypeError {
+  readonly name = 'InvalidPublicIdError';
+
+  constructor(readonly kind: string, readonly value: string) {
+    super(`Invalid ${kind} identifier: ${value}`);
+  }
+}
 
 export type PublicationId = string & { readonly brand: 'PublicationId' };
 export type LocationId = string & { readonly brand: 'LocationId' };
@@ -31,7 +39,7 @@ export function createActivityId(value: string): ActivityId {
 
 function createPublicId(value: string, kind: string): string {
   if (!PUBLIC_ID_PATTERN.test(value)) {
-    throw new TypeError(`Invalid ${kind} identifier: ${value}`);
+    throw new InvalidPublicIdError(kind, value);
   }
   return value;
 }

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { CoordinatesSchema, FeatureFlagsSchema, RouteSchema, SCHEMA_VERSION } from './index';
+import {
+  CoordinatesSchema,
+  ContractValidationError,
+  FeatureFlagsSchema,
+  RouteSchema,
+  SCHEMA_VERSION,
+  createLocationId,
+  parseRoute,
+} from './index';
 
 describe('@santa-tracker/contracts', () => {
   it('validates coordinates', () => {
@@ -27,10 +35,25 @@ describe('@santa-tracker/contracts', () => {
     expect(route.stops).toHaveLength(1);
   });
 
+  it('rejects unsupported versions with a typed error', () => {
+    try {
+      parseRoute({ schemaVersion: '2099.0.0', season: 2026, stops: [] });
+      throw new Error('expected parseRoute to reject');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(ContractValidationError);
+      expect((error as ContractValidationError).code).toBe('unsupported_schema_version');
+    }
+    expect(() => parseRoute({ schemaVersion: SCHEMA_VERSION, season: 2026, stops: [] })).toThrow(ContractValidationError);
+  });
+
+  it('validates stable public identifiers', () => {
+    expect(createLocationId('north-pole')).toBe('north-pole');
+    expect(() => createLocationId('North Pole')).toThrow(TypeError);
+  });
+
   it('defaults feature flags', () => {
     const flags = FeatureFlagsSchema.parse({});
     expect(flags.mapEnabled).toBe(true);
     expect(flags.adventEnabled).toBe(false);
   });
 });
-

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest';
 import {
   CoordinatesSchema,
   ContractValidationError,
+  ActivitySchema,
   FeatureFlagsSchema,
   RouteSchema,
   SCHEMA_VERSION,
   createLocationId,
+  parseSnapshot,
   parseRoute,
 } from './index';
 
@@ -49,6 +51,21 @@ describe('@santa-tracker/contracts', () => {
   it('validates stable public identifiers', () => {
     expect(createLocationId('north-pole')).toBe('north-pole');
     expect(() => createLocationId('North Pole')).toThrow(TypeError);
+  });
+
+  it('rejects unsupported snapshot versions with a typed error', () => {
+    try {
+      parseSnapshot({ schemaVersion: '2099.0.0' });
+      throw new Error('expected parseSnapshot to reject');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(ContractValidationError);
+      expect((error as ContractValidationError).code).toBe('unsupported_schema_version');
+    }
+  });
+
+  it('validates snapshot reports and activity IDs', () => {
+    expect(ActivitySchema.safeParse({ id: 'ornament-smash', title: 'Ornament smash' }).success).toBe(true);
+    expect(ActivitySchema.safeParse({ id: 'Ornament Smash', title: 'Ornament smash' }).success).toBe(false);
   });
 
   it('defaults feature flags', () => {

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -1,5 +1,35 @@
 import { z } from 'zod';
-import { SCHEMA_VERSION, SeasonModeValues } from './ids';
+import {
+  SCHEMA_VERSION,
+  SUPPORTED_SCHEMA_VERSIONS,
+  SeasonModeValues,
+  createActivityId,
+  createLocationId,
+  createPublicationId,
+  createSnapshotId,
+} from './ids';
+import type { ActivityId, LocationId, PublicationId, SnapshotId } from './ids';
+
+export type ContractErrorCode = 'invalid_input' | 'unsupported_schema_version';
+
+export class ContractValidationError extends Error {
+  readonly name = 'ContractValidationError';
+
+  constructor(
+    readonly code: ContractErrorCode,
+    readonly schemaName: string,
+    readonly issues: readonly z.ZodIssue[],
+  ) {
+    super(`${schemaName} ${code.replace('_', ' ')}`);
+  }
+}
+
+export const SchemaVersionSchema = z.enum(SUPPORTED_SCHEMA_VERSIONS);
+export const PublicIdSchema = z.string().min(1).regex(/^[a-z0-9]+(?:[-_][a-z0-9]+)*$/);
+export const PublicationIdSchema: z.ZodType<PublicationId, z.ZodTypeDef, string> = PublicIdSchema.transform(createPublicationId);
+export const LocationIdSchema: z.ZodType<LocationId, z.ZodTypeDef, string> = PublicIdSchema.transform(createLocationId);
+export const SnapshotIdSchema: z.ZodType<SnapshotId, z.ZodTypeDef, string> = PublicIdSchema.transform(createSnapshotId);
+export const ActivityIdSchema: z.ZodType<ActivityId, z.ZodTypeDef, string> = PublicIdSchema.transform(createActivityId);
 
 // ---------------------------------------------------------------------------
 // Primitives
@@ -17,7 +47,7 @@ export type Coordinates = z.infer<typeof CoordinatesSchema>;
 // ---------------------------------------------------------------------------
 
 export const LocationSchema = z.object({
-  id: z.string().min(1),
+  id: LocationIdSchema,
   name: z.string().min(1),
   country: z.string().min(1),
   coordinates: CoordinatesSchema,
@@ -30,7 +60,7 @@ export const LocationSchema = z.object({
 export type Location = z.infer<typeof LocationSchema>;
 
 export const RouteStopSchema = z.object({
-  locationId: z.string().min(1),
+  locationId: LocationIdSchema,
   arrivalIso: z.string().datetime({ offset: true }),
   departureIso: z.string().datetime({ offset: true }),
   durationSeconds: z.number().int().min(0),
@@ -51,9 +81,15 @@ export type Route = z.infer<typeof RouteSchema>;
 // ---------------------------------------------------------------------------
 
 export const SnapshotSchema = z.object({
-  schemaVersion: z.literal(SCHEMA_VERSION),
-  publicationId: z.string().min(1),
-  season: z.number().int(),
+  schemaVersion: SchemaVersionSchema,
+  publicationId: PublicationIdSchema,
+  snapshotId: SnapshotIdSchema,
+  season: z.number().int().min(2026),
+  author: z.string().min(1),
+  validationReport: z.object({
+    valid: z.literal(true),
+    issueCount: z.number().int().nonnegative().default(0),
+  }),
   createdAtIso: z.string().datetime({ offset: true }),
   checksum: z.string().min(8),
   route: RouteSchema,
@@ -132,14 +168,30 @@ export type SeasonalConfig = z.infer<typeof SeasonalConfigSchema>;
 // ---------------------------------------------------------------------------
 
 export function parseRoute(input: unknown): Route {
-  return RouteSchema.parse(input);
+  return parseContract(RouteSchema, input, 'Route');
 }
 
 export function parseSnapshot(input: unknown): Snapshot {
-  return SnapshotSchema.parse(input);
+  return parseContract(SnapshotSchema, input, 'Snapshot');
+}
+
+function parseContract<T extends z.ZodTypeAny>(schema: T, input: unknown, schemaName: string): z.infer<T> {
+  const version = isRecord(input) ? input.schemaVersion : undefined;
+  const result = schema.safeParse(input);
+
+  if (result.success) return result.data as z.infer<T>;
+
+  const code: ContractErrorCode =
+    typeof version === 'string' && !SUPPORTED_SCHEMA_VERSIONS.includes(version as typeof SCHEMA_VERSION)
+      ? 'unsupported_schema_version'
+      : 'invalid_input';
+  throw new ContractValidationError(code, schemaName, result.error.issues);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 export function isValidCoordinates(value: unknown): value is Coordinates {
   return CoordinatesSchema.safeParse(value).success;
 }
-

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
 import {
-  SCHEMA_VERSION,
   SUPPORTED_SCHEMA_VERSIONS,
   SeasonModeValues,
   createActivityId,
   createLocationId,
   createPublicationId,
   createSnapshotId,
+  PUBLIC_ID_PATTERN,
 } from './ids';
 import type { ActivityId, LocationId, PublicationId, SnapshotId } from './ids';
 
@@ -20,12 +20,12 @@ export class ContractValidationError extends Error {
     readonly schemaName: string,
     readonly issues: readonly z.ZodIssue[],
   ) {
-    super(`${schemaName} ${code.replace('_', ' ')}`);
+    super(`${schemaName} ${code.replaceAll('_', ' ')}`);
   }
 }
 
 export const SchemaVersionSchema = z.enum(SUPPORTED_SCHEMA_VERSIONS);
-export const PublicIdSchema = z.string().min(1).regex(/^[a-z0-9]+(?:[-_][a-z0-9]+)*$/);
+export const PublicIdSchema = z.string().min(1).regex(PUBLIC_ID_PATTERN);
 export const PublicationIdSchema: z.ZodType<PublicationId, z.ZodTypeDef, string> = PublicIdSchema.transform(createPublicationId);
 export const LocationIdSchema: z.ZodType<LocationId, z.ZodTypeDef, string> = PublicIdSchema.transform(createLocationId);
 export const SnapshotIdSchema: z.ZodType<SnapshotId, z.ZodTypeDef, string> = PublicIdSchema.transform(createSnapshotId);
@@ -69,12 +69,20 @@ export const RouteStopSchema = z.object({
 export type RouteStop = z.infer<typeof RouteStopSchema>;
 
 export const RouteSchema = z.object({
-  schemaVersion: z.literal(SCHEMA_VERSION),
+  schemaVersion: SchemaVersionSchema,
   season: z.number().int().min(2026),
   stops: z.array(RouteStopSchema).min(1),
 });
 
 export type Route = z.infer<typeof RouteSchema>;
+
+export const ActivitySchema = z.object({
+  id: ActivityIdSchema,
+  title: z.string().min(1),
+  description: z.string().optional(),
+});
+
+export type Activity = z.infer<typeof ActivitySchema>;
 
 // ---------------------------------------------------------------------------
 // Snapshot (immutable published artifact)
@@ -87,8 +95,9 @@ export const SnapshotSchema = z.object({
   season: z.number().int().min(2026),
   author: z.string().min(1),
   validationReport: z.object({
-    valid: z.literal(true),
+    valid: z.boolean(),
     issueCount: z.number().int().nonnegative().default(0),
+    issues: z.array(z.object({ path: z.string().min(1), message: z.string().min(1) })).default([]),
   }),
   createdAtIso: z.string().datetime({ offset: true }),
   checksum: z.string().min(8),
@@ -176,20 +185,15 @@ export function parseSnapshot(input: unknown): Snapshot {
 }
 
 function parseContract<T extends z.ZodTypeAny>(schema: T, input: unknown, schemaName: string): z.infer<T> {
-  const version = isRecord(input) ? input.schemaVersion : undefined;
   const result = schema.safeParse(input);
 
   if (result.success) return result.data as z.infer<T>;
 
-  const code: ContractErrorCode =
-    typeof version === 'string' && !SUPPORTED_SCHEMA_VERSIONS.includes(version as typeof SCHEMA_VERSION)
-      ? 'unsupported_schema_version'
-      : 'invalid_input';
+  const hasUnsupportedVersion = result.error.issues.some(
+    (issue) => issue.path.length === 1 && issue.path[0] === 'schemaVersion' && issue.code === 'invalid_enum_value',
+  );
+  const code: ContractErrorCode = hasUnsupportedVersion ? 'unsupported_schema_version' : 'invalid_input';
   throw new ContractValidationError(code, schemaName, result.error.issues);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }
 
 export function isValidCoordinates(value: unknown): value is Coordinates {

--- a/packages/test-fixtures/src/routes.ts
+++ b/packages/test-fixtures/src/routes.ts
@@ -1,4 +1,4 @@
-import { SCHEMA_VERSION, type Route } from '@santa-tracker/contracts';
+import { SCHEMA_VERSION, createLocationId, type Route } from '@santa-tracker/contracts';
 
 export function createDeterministicRoute(): Route {
   const base = Date.parse('2026-12-24T00:00:00.000Z');
@@ -7,19 +7,19 @@ export function createDeterministicRoute(): Route {
     season: 2026,
     stops: [
       {
-        locationId: 'north-pole',
+        locationId: createLocationId('north-pole'),
         arrivalIso: new Date(base).toISOString(),
         departureIso: new Date(base + 60_000).toISOString(),
         durationSeconds: 60,
       },
       {
-        locationId: 'auckland-nz',
+        locationId: createLocationId('auckland-nz'),
         arrivalIso: new Date(base + 120_000).toISOString(),
         departureIso: new Date(base + 180_000).toISOString(),
         durationSeconds: 60,
       },
       {
-        locationId: 'tokyo-jp',
+        locationId: createLocationId('tokyo-jp'),
         arrivalIso: new Date(base + 240_000).toISOString(),
         departureIso: new Date(base + 300_000).toISOString(),
         durationSeconds: 60,
@@ -35,13 +35,13 @@ export function createAntarcticRoute(): Route {
     season: 2026,
     stops: [
       {
-        locationId: 'fiji',
+        locationId: createLocationId('fiji'),
         arrivalIso: '2026-12-24T00:00:00.000Z',
         departureIso: '2026-12-24T00:05:00.000Z',
         durationSeconds: 300,
       },
       {
-        locationId: 'samoa',
+        locationId: createLocationId('samoa'),
         arrivalIso: '2026-12-24T00:10:00.000Z',
         departureIso: '2026-12-24T00:15:00.000Z',
         durationSeconds: 300,

--- a/packages/test-fixtures/src/snapshots.ts
+++ b/packages/test-fixtures/src/snapshots.ts
@@ -9,7 +9,7 @@ export function createDeterministicSnapshot(overrides: Partial<Snapshot> = {}): 
     snapshotId: createSnapshotId('snapshot-deterministic-001'),
     season: 2026,
     author: 'fixture',
-    validationReport: { valid: true, issueCount: 0 },
+    validationReport: { valid: true, issueCount: 0, issues: [] },
     createdAtIso: '2026-12-01T00:00:00.000Z',
     checksum: 'sha256:deterministic-checksum-001',
     route,

--- a/packages/test-fixtures/src/snapshots.ts
+++ b/packages/test-fixtures/src/snapshots.ts
@@ -1,16 +1,18 @@
-import { SCHEMA_VERSION, type Snapshot } from '@santa-tracker/contracts';
+import { SCHEMA_VERSION, createPublicationId, createSnapshotId, type Snapshot } from '@santa-tracker/contracts';
 import { createDeterministicRoute } from './routes';
 
 export function createDeterministicSnapshot(overrides: Partial<Snapshot> = {}): Snapshot {
   const route = createDeterministicRoute();
   return {
     schemaVersion: SCHEMA_VERSION,
-    publicationId: 'pub-deterministic-001',
+    publicationId: createPublicationId('pub-deterministic-001'),
+    snapshotId: createSnapshotId('snapshot-deterministic-001'),
     season: 2026,
+    author: 'fixture',
+    validationReport: { valid: true, issueCount: 0 },
     createdAtIso: '2026-12-01T00:00:00.000Z',
     checksum: 'sha256:deterministic-checksum-001',
     route,
     ...overrides,
   };
 }
-

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
+      '@santa-tracker/test-fixtures':
+        specifier: workspace:*
+        version: link:../../packages/test-fixtures
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3


### PR DESCRIPTION
## Summary

- Add validated public ID schemas and constructors for locations, publications, snapshots, and activities.
- Add versioned route and snapshot contracts with publication metadata, checksums, timestamps, and typed unsupported-version errors.
- Update deterministic fixtures and consume them from the web contract test.
- Update the per-PR changelog.

## Verification

- corepack pnpm typecheck`n- corepack pnpm lint`n- corepack pnpm test (38 passed, 2 skipped database integration tests without PostgreSQL)
- Package typecheck and Next.js production build passed.

Closes #211