### PR TITLE
feat(fixtures): migrate legacy route and Advent data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — per-PR exhaustive (enforced in CI)
 
+## [PR #] - 2026-08-28 - feat(ui): add Storybook design baseline
+
+- **Issue:** Closes #216, establishing the first shared UI baseline for the Christmas 2026 redesign.
+- **Tokens:** Adds color, typography, spacing, layer, motion, focus, radius, and seasonal-state tokens, including CSS overrides for reduced motion and high contrast.
+- **Stories:** Adds Button variants and a seasonal token gallery with mobile, high-contrast, and reduced-motion toolbar states.
+- **Checks:** Adds Storybook build, axe accessibility, and per-story PNG screenshot checks to the workspace CI job.
+- **Docs:** Adds `docs/UI_STORYBOOK.md` with local and CI-style commands.
+
 ## [Unreleased] — Shared public contracts (#211)
 
 - Added validated public ID schemas and constructors for locations, publications, snapshots, and activities.
@@ -8,6 +16,12 @@
 - Breaking contract change: snapshots now require `snapshotId`, `author`, and `validationReport`; old snapshot payloads must be republished with the current schema version.
 
 ## [Unreleased] — Flask retirement #221
+
+## [Unreleased] — Migration fixtures #218
+
+- Added shared Zod schemas and deeply frozen fixtures for all 185 nodes in the 2025 route and all 24 Advent days.
+- The migration schema records two source exceptions without rewriting the fixture: unwrapped longitudes up to 360 degrees and legacy IDs containing repeated underscores. Runtime normalization still applies the canonical coordinate and ID rules.
+- Removed the Next.js resolver's fallback to retired Flask data, so the new runtime has one route and Advent data source.
 
 ### Foundation — retire Flask runtime after parity acceptance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@
 
 - Added shared Zod schemas and deeply frozen fixtures for all 185 nodes in the 2025 route and all 24 Advent days.
 - The migration schema records two source exceptions without rewriting the fixture: unwrapped longitudes up to 360 degrees and legacy IDs containing repeated underscores. Runtime normalization still applies the canonical coordinate and ID rules.
+- Published SHA-256 values in the fixture module make accidental source drift visible in tests. Legacy Advent payloads stay intentionally open-ended because the copied source uses different shapes by content type; a later content contract can tighten those fields without rewriting this provenance fixture.
 - Removed the Next.js resolver's fallback to retired Flask data, so the new runtime has one route and Advent data source.
+- Removed the remaining Next.js trial-route fallback to `src/static/data`; trial data now stays under the new app data directory.
 
 ### Foundation — retire Flask runtime after parity acceptance
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ packages/
   database/              # Drizzle placeholder (issue #210); filesystem store provides parity now
   ui/                    # Shared primitives
   activity-sdk/          # Activity lifecycle
-  test-fixtures/         # Clocks, routes, snapshots
+  test-fixtures/         # Clocks, routes, snapshots, and frozen legacy fixtures
 archive/
   flask-legacy/          # Retired src/app.py, config.py, utils, requirements
   route-data-2025-12-20/ # Snapshot of Route Data/ at audit commit 41c96a6

--- a/apps/web/src/lib/config.ts
+++ b/apps/web/src/lib/config.ts
@@ -29,7 +29,6 @@ function getDataPath(filename: string): string {
   const candidates = [
     path.join(process.cwd(), "data", filename),
     path.join(process.cwd(), "apps", "web", "data", filename),
-    path.join(process.cwd(), "..", "..", "src", "static", "data", filename),
   ];
   return candidates.find(candidate => existsSync(candidate)) ?? candidates[0]!;
 }

--- a/apps/web/src/lib/config.ts
+++ b/apps/web/src/lib/config.ts
@@ -34,11 +34,9 @@ function getDataPath(filename: string): string {
 }
 
 export async function getTrialRoutePath(): Promise<string> {
-  const legacy = path.join(process.cwd(), "..", "..", "src", "static", "data", "trial_route.json");
-  const appData = path.join(process.cwd(), "data", "trial_route.json");
-  try {
-    await fs.access(legacy);
-    return legacy;
-  } catch {}
-  return appData;
+  const candidates = [
+    path.join(process.cwd(), "data", "trial_route.json"),
+    path.join(process.cwd(), "apps", "web", "data", "trial_route.json"),
+  ];
+  return candidates.find(candidate => existsSync(candidate)) ?? candidates[0]!;
 }

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -139,6 +139,8 @@ export const LegacyAdventDaySchema = z.object({
   title: z.string().min(1),
   unlock_time: z.string().datetime({ offset: true }),
   content_type: z.enum(['fact', 'game', 'story', 'video', 'activity', 'quiz']),
+  // Legacy content types have different payload shapes. Keep the copied source
+  // lossless here; the editor/content contracts can tighten each type later.
   payload: z.record(z.unknown()),
 });
 

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -76,6 +76,88 @@ export const RouteSchema = z.object({
 
 export type Route = z.infer<typeof RouteSchema>;
 
+// ---------------------------------------------------------------------------
+// Legacy migration fixtures
+// ---------------------------------------------------------------------------
+
+const LegacyScheduleSchema = z.object({
+  arrival_utc: z.string().datetime({ offset: true }).nullable().optional(),
+  departure_utc: z.string().datetime({ offset: true }).nullable().optional(),
+  local_arrival_time: z.string().min(1).nullable().optional(),
+  time_window_status: z.string().min(1).nullable().optional(),
+});
+
+const LegacyStopExperienceSchema = z.object({
+  duration_seconds: z.number().int().nonnegative().nullable().optional(),
+  camera_zoom: z.number().int().nullable().optional(),
+  weather_condition: z.string().min(1).nullable().optional(),
+  presents_delivered_at_stop: z.number().int().nonnegative().nullable().optional(),
+});
+
+const LegacyTransitSchema = z.object({
+  description: z.string().min(1).nullable().optional(),
+  duration_seconds: z.number().int().nonnegative().nullable().optional(),
+  distance_km: z.number().nonnegative().nullable().optional(),
+  speed_curve: z.string().min(1).nullable().optional(),
+  speed_kmh: z.number().nonnegative().nullable().optional(),
+  camera_zoom: z.number().int().nullable().optional(),
+});
+
+export const LegacyRouteNodeSchema = z.object({
+  comment: z.string().nullable().optional(),
+  // Legacy IDs include repeated underscores. The canonical ID schema remains strict.
+  id: z.string().min(1),
+  type: z.string().min(1),
+  location: z.object({
+    name: z.string().min(1),
+    region: z.string().min(1),
+    lat: z.number().min(-90).max(90),
+    // The old route stores unwrapped longitudes for antimeridian continuity.
+    lng: z.number().min(-360).max(360),
+    timezone_offset: z.number().min(-12).max(14),
+  }),
+  stop_experience: LegacyStopExperienceSchema,
+  schedule: LegacyScheduleSchema,
+  transit_to_here: LegacyTransitSchema.nullable(),
+});
+
+export type LegacyRouteNode = z.infer<typeof LegacyRouteNodeSchema>;
+
+export const LegacyRouteFixtureSchema = z.object({
+  meta: z.object({
+    year: z.number().int(),
+    route_version: z.string().min(1),
+    generated_at: z.string().datetime({ offset: true }),
+  }),
+  route_nodes: z.array(LegacyRouteNodeSchema).min(1),
+});
+
+export type LegacyRouteFixture = z.infer<typeof LegacyRouteFixtureSchema>;
+
+export const LegacyAdventDaySchema = z.object({
+  day: z.number().int().min(1).max(24),
+  title: z.string().min(1),
+  unlock_time: z.string().datetime({ offset: true }),
+  content_type: z.enum(['fact', 'game', 'story', 'video', 'activity', 'quiz']),
+  payload: z.record(z.unknown()),
+});
+
+export type LegacyAdventDay = z.infer<typeof LegacyAdventDaySchema>;
+
+export const LegacyAdventFixtureSchema = z.object({
+  days: z.array(LegacyAdventDaySchema).length(24).superRefine((days, context) => {
+    const dayNumbers = days.map(day => day.day);
+    if (new Set(dayNumbers).size !== dayNumbers.length) {
+      context.addIssue({ code: z.ZodIssueCode.custom, message: 'Advent days must be unique' });
+    }
+    if (dayNumbers.some((day, index) => day !== index + 1)) {
+      context.addIssue({ code: z.ZodIssueCode.custom, message: 'Advent days must contain 1 through 24 in order' });
+    }
+  }),
+});
+
+export type LegacyAdventFixture = z.infer<typeof LegacyAdventFixtureSchema>;
+
 export const ActivitySchema = z.object({
   id: ActivityIdSchema,
   title: z.string().min(1),

--- a/packages/test-fixtures/src/data/advent-calendar-2024.json
+++ b/packages/test-fixtures/src/data/advent-calendar-2024.json
@@ -1,0 +1,172 @@
+{
+  "days": [
+    {
+      "day": 1,
+      "title": "Day 1",
+      "unlock_time": "2024-12-01T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 1"}
+    },
+    {
+      "day": 2,
+      "title": "Day 2",
+      "unlock_time": "2024-12-02T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 2"}
+    },
+    {
+      "day": 3,
+      "title": "Day 3",
+      "unlock_time": "2024-12-03T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 3"}
+    },
+    {
+      "day": 4,
+      "title": "Day 4",
+      "unlock_time": "2024-12-04T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 4"}
+    },
+    {
+      "day": 5,
+      "title": "Day 5",
+      "unlock_time": "2024-12-05T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 5"}
+    },
+    {
+      "day": 6,
+      "title": "Day 6",
+      "unlock_time": "2024-12-06T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 6"}
+    },
+    {
+      "day": 7,
+      "title": "Day 7",
+      "unlock_time": "2024-12-07T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 7"}
+    },
+    {
+      "day": 8,
+      "title": "Day 8",
+      "unlock_time": "2024-12-08T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 8"}
+    },
+    {
+      "day": 9,
+      "title": "Day 9",
+      "unlock_time": "2024-12-09T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 9"}
+    },
+    {
+      "day": 10,
+      "title": "Day 10",
+      "unlock_time": "2024-12-10T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 10"}
+    },
+    {
+      "day": 11,
+      "title": "Day 11",
+      "unlock_time": "2024-12-11T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 11"}
+    },
+    {
+      "day": 12,
+      "title": "Day 12",
+      "unlock_time": "2024-12-12T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 12"}
+    },
+    {
+      "day": 13,
+      "title": "Day 13",
+      "unlock_time": "2024-12-13T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 13"}
+    },
+    {
+      "day": 14,
+      "title": "Day 14",
+      "unlock_time": "2024-12-14T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 14"}
+    },
+    {
+      "day": 15,
+      "title": "Day 15",
+      "unlock_time": "2024-12-15T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 15"}
+    },
+    {
+      "day": 16,
+      "title": "Day 16",
+      "unlock_time": "2024-12-16T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 16"}
+    },
+    {
+      "day": 17,
+      "title": "Day 17",
+      "unlock_time": "2024-12-17T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 17"}
+    },
+    {
+      "day": 18,
+      "title": "Day 18",
+      "unlock_time": "2024-12-18T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 18"}
+    },
+    {
+      "day": 19,
+      "title": "Day 19",
+      "unlock_time": "2024-12-19T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 19"}
+    },
+    {
+      "day": 20,
+      "title": "Day 20",
+      "unlock_time": "2024-12-20T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 20"}
+    },
+    {
+      "day": 21,
+      "title": "Day 21",
+      "unlock_time": "2024-12-21T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 21"}
+    },
+    {
+      "day": 22,
+      "title": "Day 22",
+      "unlock_time": "2024-12-22T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 22"}
+    },
+    {
+      "day": 23,
+      "title": "Day 23",
+      "unlock_time": "2024-12-23T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 23"}
+    },
+    {
+      "day": 24,
+      "title": "Day 24",
+      "unlock_time": "2024-12-24T00:00:00Z",
+      "content_type": "fact",
+      "payload": {"text": "Content for day 24"}
+    }
+  ]
+}

--- a/packages/test-fixtures/src/data/santa-route-2025.json
+++ b/packages/test-fixtures/src/data/santa-route-2025.json
@@ -1,0 +1,5920 @@
+{
+  "meta": {
+    "year": 2025,
+    "route_version": "1.0",
+    "generated_at": "2025-12-20T21:42:19.778Z"
+  },
+  "route_nodes": [
+    {
+      "comment": "--- NODE 0: THE ANCHOR (HARD LOCKED) ---",
+      "id": "node_000_north_pole",
+      "type": "START",
+      "location": {
+        "name": "North Pole",
+        "region": "Arctic",
+        "lat": 80,
+        "lng": 180,
+        "timezone_offset": 0
+      },
+      "stop_experience": {
+        "duration_seconds": 0,
+        "camera_zoom": 4,
+        "weather_condition": "blizzard",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": null,
+        "departure_utc": "2025-12-24T10:34:25.000Z"
+      },
+      "transit_to_here": null
+    },
+    {
+      "comment": "--- NODE 33: Magadan ---",
+      "id": "node_033_magadan",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Magadan",
+        "region": "Russia",
+        "lat": 59.55963599909173,
+        "lng": 150.7986831665039,
+        "timezone_offset": 12
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T10:45:00.000Z",
+        "departure_utc": "2025-12-24T10:46:00.000Z",
+        "local_arrival_time": "22:45",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "The Launch",
+        "duration_seconds": 635,
+        "distance_km": 2469,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 32: Petropavlovsk-Kamchatsky ---",
+      "id": "node_032_petropavlovsk_kamcha",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Petropavlovsk-Kamchatsky",
+        "region": "Russia",
+        "lat": 53.019533543265226,
+        "lng": 158.6484146118164,
+        "timezone_offset": 12
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T10:49:44.000Z",
+        "departure_utc": "2025-12-24T10:50:44.000Z",
+        "local_arrival_time": "22:50",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Petropavlovsk-Kamchatsky",
+        "duration_seconds": 224,
+        "distance_km": 873,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 3: Tabwakea ---",
+      "id": "node_003_unknown_location",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Tabwakea",
+        "region": "Kiribati",
+        "lat": 2.0195211267113553,
+        "lng": 202.51338958740237,
+        "timezone_offset": 14
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T10:57:41.000Z",
+        "departure_utc": "2025-12-24T10:58:41.000Z",
+        "local_arrival_time": "00:58",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Long Haul to Kiribati",
+        "duration_seconds": 417,
+        "distance_km": 6951,
+        "speed_curve": "HYPERSONIC_LONG",
+        "speed_kmh": 60000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 4: Nukunonu ---",
+      "id": "node_004_unknown_location",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Nukunonu",
+        "region": "Tokelau",
+        "lat": -9.200096532018351,
+        "lng": 188.1515979766846,
+        "timezone_offset": 13
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T11:07:21.000Z",
+        "departure_utc": "2025-12-24T11:08:21.000Z",
+        "local_arrival_time": "00:07",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Long Haul to Tokelau",
+        "duration_seconds": 520,
+        "distance_km": 2022,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 5: Apia ---",
+      "id": "node_005_unknown_location",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Apia",
+        "region": "Samoa",
+        "lat": -13.834746332602325,
+        "lng": 188.23047637939456,
+        "timezone_offset": 13
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T11:15:34.000Z",
+        "departure_utc": "2025-12-24T11:16:34.000Z",
+        "local_arrival_time": "00:16",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Apia",
+        "duration_seconds": 433,
+        "distance_km": 515,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 4284,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 6: Leimatu'a ---",
+      "id": "node_008_unknown_location",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Leimatu'a",
+        "region": "Tonga",
+        "lat": -18.598744417722013,
+        "lng": 186.01913452148438,
+        "timezone_offset": 13
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T11:21:56.000Z",
+        "departure_utc": "2025-12-24T11:22:56.000Z",
+        "local_arrival_time": "00:22",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Leimatu'a",
+        "duration_seconds": 322,
+        "distance_km": 580,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 6486,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 7: Pangai ---",
+      "id": "node_006_unknown_location",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Pangai",
+        "region": "Tonga",
+        "lat": -19.806762085139223,
+        "lng": 185.65452575683597,
+        "timezone_offset": 13
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T11:27:01.000Z",
+        "departure_utc": "2025-12-24T11:28:01.000Z",
+        "local_arrival_time": "00:27",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Pangai",
+        "duration_seconds": 245,
+        "distance_km": 140,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 8: Tofoa ---",
+      "id": "node_007_unknown_location",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Tofoa",
+        "region": "Tonga",
+        "lat": -21.155597999307638,
+        "lng": 184.77776527404788,
+        "timezone_offset": 13
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T11:33:09.000Z",
+        "departure_utc": "2025-12-24T11:34:09.000Z",
+        "local_arrival_time": "00:33",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Tofoa",
+        "duration_seconds": 308,
+        "distance_km": 176,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 9: Suva ---",
+      "id": "node_009_suva",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Suva",
+        "region": "Fiji",
+        "lat": -18.1430786398645,
+        "lng": 178.44079971313477,
+        "timezone_offset": 12
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T11:37:51.000Z",
+        "departure_utc": "2025-12-24T11:38:51.000Z",
+        "local_arrival_time": "23:38",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Suva",
+        "duration_seconds": 222,
+        "distance_km": 743,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 12062,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 10: Lautoka ---",
+      "id": "node_010_lautoka",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Lautoka",
+        "region": "Fiji",
+        "lat": -17.604757089727155,
+        "lng": 177.4518585205078,
+        "timezone_offset": 12
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T11:42:23.000Z",
+        "departure_utc": "2025-12-24T11:43:23.000Z",
+        "local_arrival_time": "23:42",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Lautoka",
+        "duration_seconds": 212,
+        "distance_km": 121,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 11: Auckland ---",
+      "id": "node_011_waitemat_",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Auckland",
+        "region": "New Zealand",
+        "lat": -36.852702785393014,
+        "lng": 174.76226806640628,
+        "timezone_offset": 12
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T11:52:38.000Z",
+        "departure_utc": "2025-12-24T11:53:38.000Z",
+        "local_arrival_time": "23:53",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Long Haul to New Zealand",
+        "duration_seconds": 555,
+        "distance_km": 2156,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 12: Napier ---",
+      "id": "node_012_napier",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Napier",
+        "region": "New Zealand",
+        "lat": -39.49026449493616,
+        "lng": 176.9173049926758,
+        "timezone_offset": 12
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T12:03:50.000Z",
+        "departure_utc": "2025-12-24T12:04:50.000Z",
+        "local_arrival_time": "00:04",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Napier",
+        "duration_seconds": 612,
+        "distance_km": 349,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 13: Christchurch ---",
+      "id": "node_097_unknown_location",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Christchurch",
+        "region": "New Zealand",
+        "lat": -41.29225364215946,
+        "lng": 174.781494140625,
+        "timezone_offset": 12
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T12:12:44.000Z",
+        "departure_utc": "2025-12-24T12:13:44.000Z",
+        "local_arrival_time": "00:13",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Christchurch",
+        "duration_seconds": 474,
+        "distance_km": 270,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 14: Christchurch ---",
+      "id": "node_014_linwood_central_heat",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Christchurch",
+        "region": "New Zealand",
+        "lat": -43.53411382594074,
+        "lng": 172.64190673828128,
+        "timezone_offset": 12
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T12:22:39.000Z",
+        "departure_utc": "2025-12-24T12:23:39.000Z",
+        "local_arrival_time": "00:23",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Christchurch",
+        "duration_seconds": 535,
+        "distance_km": 305,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 16: Noumea ---",
+      "id": "node_016_noumea",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Noumea",
+        "region": "France",
+        "lat": -22.277024424821043,
+        "lng": 166.44973754882815,
+        "timezone_offset": 11
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T12:34:04.000Z",
+        "departure_utc": "2025-12-24T12:35:04.000Z",
+        "local_arrival_time": "23:34",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Long Haul to France",
+        "duration_seconds": 625,
+        "distance_km": 2432,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 17: Port Vila ---",
+      "id": "node_017_port_vila",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Port Vila",
+        "region": "Vanuatu",
+        "lat": -17.742146901328233,
+        "lng": 168.32290649414065,
+        "timezone_offset": 11
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T12:41:22.000Z",
+        "departure_utc": "2025-12-24T12:42:22.000Z",
+        "local_arrival_time": "23:41",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Port Vila",
+        "duration_seconds": 378,
+        "distance_km": 541,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 5153,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 18: Honiara ---",
+      "id": "node_018_honiara",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Honiara",
+        "region": "Solomon Islands",
+        "lat": -9.439579089429348,
+        "lng": 159.96643066406253,
+        "timezone_offset": 11
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T12:47:54.000Z",
+        "departure_utc": "2025-12-24T12:48:54.000Z",
+        "local_arrival_time": "23:48",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Honiara",
+        "duration_seconds": 332,
+        "distance_km": 1291,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 20: Port Moresby ---",
+      "id": "node_020_port_moresby",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Port Moresby",
+        "region": "Papua New Guinea",
+        "lat": -9.476323241250936,
+        "lng": 147.15362548828128,
+        "timezone_offset": 10
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T12:54:55.000Z",
+        "departure_utc": "2025-12-24T12:55:55.000Z",
+        "local_arrival_time": "22:55",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Port Moresby",
+        "duration_seconds": 361,
+        "distance_km": 1405,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 21: Townsville ---",
+      "id": "node_022_townsville",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Townsville",
+        "region": "Australia",
+        "lat": -19.257106390950046,
+        "lng": 146.82017326354983,
+        "timezone_offset": 10
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T13:00:35.000Z",
+        "departure_utc": "2025-12-24T13:01:35.000Z",
+        "local_arrival_time": "23:01",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Townsville",
+        "duration_seconds": 280,
+        "distance_km": 1088,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 22: Brisbane ---",
+      "id": "node_022_unknown_location",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Brisbane",
+        "region": "Australia",
+        "lat": -27.46883054884205,
+        "lng": 153.0216979980469,
+        "timezone_offset": 10
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T13:06:21.000Z",
+        "departure_utc": "2025-12-24T13:08:21.000Z",
+        "local_arrival_time": "23:06",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Brisbane",
+        "duration_seconds": 286,
+        "distance_km": 1111,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 23: Sydney ---",
+      "id": "node_023_sydney",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Sydney",
+        "region": "Australia",
+        "lat": -33.86998795846261,
+        "lng": 151.20800971984866,
+        "timezone_offset": 10
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T13:12:06.000Z",
+        "departure_utc": "2025-12-24T13:14:06.000Z",
+        "local_arrival_time": "23:12",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Sydney",
+        "duration_seconds": 225,
+        "distance_km": 733,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 11698,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 24: Melbourne ---",
+      "id": "node_024_melbourne",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Melbourne",
+        "region": "Australia",
+        "lat": -37.81629348024508,
+        "lng": 144.94949340820315,
+        "timezone_offset": 10
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T13:17:58.000Z",
+        "departure_utc": "2025-12-24T13:19:58.000Z",
+        "local_arrival_time": "23:18",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Melbourne",
+        "duration_seconds": 232,
+        "distance_km": 714,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 11077,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 25: Adelaide ---",
+      "id": "node_025_adelaide",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Adelaide",
+        "region": "Australia",
+        "lat": -34.93097858831627,
+        "lng": 138.59252929687503,
+        "timezone_offset": 9.5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T13:24:20.000Z",
+        "departure_utc": "2025-12-24T13:25:20.000Z",
+        "local_arrival_time": "22:54",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Adelaide",
+        "duration_seconds": 262,
+        "distance_km": 653,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 8985,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 26: Darwin ---",
+      "id": "node_026_darwin",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Darwin",
+        "region": "Australia",
+        "lat": -12.462893639175467,
+        "lng": 130.84081649780276,
+        "timezone_offset": 9.5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T13:36:33.000Z",
+        "departure_utc": "2025-12-24T13:37:33.000Z",
+        "local_arrival_time": "23:07",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Long Haul to Australia",
+        "duration_seconds": 673,
+        "distance_km": 2618,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 27: Ambon ---",
+      "id": "node_028_ambon",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Ambon",
+        "region": "Indonesia",
+        "lat": -3.6960499542708916,
+        "lng": 128.17920684814456,
+        "timezone_offset": 9
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T13:41:55.000Z",
+        "departure_utc": "2025-12-24T13:42:55.000Z",
+        "local_arrival_time": "22:42",
+        "time_window_status": "YELLOW"
+      },
+      "transit_to_here": {
+        "description": "Flight to Ambon",
+        "duration_seconds": 262,
+        "distance_km": 1018,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 28: Sorong ---",
+      "id": "node_027_sorong",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Sorong",
+        "region": "Indonesia",
+        "lat": -0.8664277764949366,
+        "lng": 131.25125885009768,
+        "timezone_offset": 9
+      },
+      "stop_experience": {
+        "duration_seconds": 0,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T13:53:54.000Z",
+        "departure_utc": "2025-12-24T13:53:54.000Z",
+        "local_arrival_time": "22:54",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Sorong",
+        "duration_seconds": 659,
+        "distance_km": 464,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 2535,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 29: Osaka ---",
+      "id": "node_029_osaka",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Osaka",
+        "region": "Japan",
+        "lat": 34.687427949314845,
+        "lng": 135.49987792968753,
+        "timezone_offset": 9
+      },
+      "stop_experience": {
+        "duration_seconds": 0,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T14:10:57.000Z",
+        "departure_utc": "2025-12-24T14:10:57.000Z",
+        "local_arrival_time": "23:11",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Long Haul to Japan",
+        "duration_seconds": 1023,
+        "distance_km": 3978,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 3
+      }
+    },
+    {
+      "comment": "--- NODE 30: Tokyo ---",
+      "id": "node_030_chiyoda",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Tokyo",
+        "region": "Japan",
+        "lat": 35.67291625588,
+        "lng": 139.75433349609378,
+        "timezone_offset": 9
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T14:22:43.000Z",
+        "departure_utc": "2025-12-24T14:24:43.000Z",
+        "local_arrival_time": "23:23",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Tokyo",
+        "duration_seconds": 706,
+        "distance_km": 402,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 31: Kushiro ---",
+      "id": "node_031_kushiro",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Kushiro",
+        "region": "Japan",
+        "lat": 42.98857645832184,
+        "lng": 144.36035156250003,
+        "timezone_offset": 9
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T14:28:36.000Z",
+        "departure_utc": "2025-12-24T14:29:36.000Z",
+        "local_arrival_time": "23:29",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Kushiro",
+        "duration_seconds": 233,
+        "distance_km": 904,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 30: Vladivostok ---",
+      "id": "node_035_vladivostok",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Vladivostok",
+        "region": "Russia",
+        "lat": 43.113014204188914,
+        "lng": 131.87438964843753,
+        "timezone_offset": 9
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T14:33:57.000Z",
+        "departure_utc": "2025-12-24T14:34:57.000Z",
+        "local_arrival_time": "23:34",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Vladivostok",
+        "duration_seconds": 261,
+        "distance_km": 1014,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 32: Ulaanbaatar ---",
+      "id": "node_051_ulaanbaatar",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Ulaanbaatar",
+        "region": "Mongolia",
+        "lat": 47.917262432162865,
+        "lng": 106.91654205322267,
+        "timezone_offset": 8
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T14:43:33.000Z",
+        "departure_utc": "2025-12-24T14:44:33.000Z",
+        "local_arrival_time": "22:44",
+        "time_window_status": "YELLOW"
+      },
+      "transit_to_here": {
+        "description": "Long Haul to Mongolia",
+        "duration_seconds": 516,
+        "distance_km": 2007,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 33: Beijing ---",
+      "id": "node_035_beijing",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Beijing",
+        "region": "China",
+        "lat": 39.90973623453719,
+        "lng": 116.38366699218751,
+        "timezone_offset": 8
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T14:49:33.000Z",
+        "departure_utc": "2025-12-24T14:51:33.000Z",
+        "local_arrival_time": "22:50",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Beijing",
+        "duration_seconds": 300,
+        "distance_km": 1168,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 34: Zhengzhou ---",
+      "id": "node_039_zhongyuan_district",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Zhengzhou",
+        "region": "China",
+        "lat": 34.744997854274125,
+        "lng": 113.62060546875001,
+        "timezone_offset": 8
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T14:56:14.000Z",
+        "departure_utc": "2025-12-24T14:57:14.000Z",
+        "local_arrival_time": "22:56",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Zhengzhou",
+        "duration_seconds": 281,
+        "distance_km": 624,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 7991,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 35: Chengdu ---",
+      "id": "node_038_chengdu",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Chengdu",
+        "region": "China",
+        "lat": 30.661540870820918,
+        "lng": 104.0625,
+        "timezone_offset": 8
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T15:01:32.000Z",
+        "departure_utc": "2025-12-24T15:03:32.000Z",
+        "local_arrival_time": "23:02",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Chengdu",
+        "duration_seconds": 258,
+        "distance_km": 1002,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 36: Shanghai ---",
+      "id": "node_036_shanghai",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Shanghai",
+        "region": "China",
+        "lat": 31.224545779641634,
+        "lng": 121.47171020507814,
+        "timezone_offset": 8
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T15:10:39.000Z",
+        "departure_utc": "2025-12-24T15:12:39.000Z",
+        "local_arrival_time": "23:11",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Shanghai",
+        "duration_seconds": 427,
+        "distance_km": 1660,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 37: Taipei ---",
+      "id": "node_039_taipei",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Taipei",
+        "region": "Taiwan",
+        "lat": 25.03957128205317,
+        "lng": 121.54998779296876,
+        "timezone_offset": 8
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T15:16:42.000Z",
+        "departure_utc": "2025-12-24T15:17:42.000Z",
+        "local_arrival_time": "23:17",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Taipei",
+        "duration_seconds": 243,
+        "distance_km": 688,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 10169,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 38: Manila ---",
+      "id": "node_040_manila",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Manila",
+        "region": "Philippines",
+        "lat": 14.588899572738569,
+        "lng": 120.9752655029297,
+        "timezone_offset": 8
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T15:22:41.000Z",
+        "departure_utc": "2025-12-24T15:23:41.000Z",
+        "local_arrival_time": "23:23",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Manila",
+        "duration_seconds": 299,
+        "distance_km": 1164,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 39: Davao City ---",
+      "id": "node_041_davao_city",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Davao City",
+        "region": "Philippines",
+        "lat": 7.068185318145826,
+        "lng": 125.59707641601564,
+        "timezone_offset": 8
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T15:27:52.000Z",
+        "departure_utc": "2025-12-24T15:28:52.000Z",
+        "local_arrival_time": "23:28",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Davao City",
+        "duration_seconds": 251,
+        "distance_km": 977,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 40: Tarakan ---",
+      "id": "node_042_tarakan",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Tarakan",
+        "region": "Indonesia",
+        "lat": 3.2940822283128175,
+        "lng": 117.62786865234376,
+        "timezone_offset": 8
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T15:33:03.000Z",
+        "departure_utc": "2025-12-24T15:34:03.000Z",
+        "local_arrival_time": "23:33",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Tarakan",
+        "duration_seconds": 251,
+        "distance_km": 977,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 23: Perth ---",
+      "id": "node_043_perth",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Perth",
+        "region": "Australia",
+        "lat": -31.961483557268544,
+        "lng": 115.8563232421875,
+        "timezone_offset": 8
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T15:50:52.000Z",
+        "departure_utc": "2025-12-24T15:51:52.000Z",
+        "local_arrival_time": "23:51",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Long Haul to Australia",
+        "duration_seconds": 1009,
+        "distance_km": 3925,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 3
+      }
+    },
+    {
+      "comment": "--- NODE 41: Jakarta ---",
+      "id": "node_044_central_jakarta",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Jakarta",
+        "region": "Indonesia",
+        "lat": -6.162400921526583,
+        "lng": 106.85302734375001,
+        "timezone_offset": 7
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T16:04:48.000Z",
+        "departure_utc": "2025-12-24T16:05:48.000Z",
+        "local_arrival_time": "23:05",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Long Haul to Indonesia",
+        "duration_seconds": 776,
+        "distance_km": 3017,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 42: Singapore ---",
+      "id": "node_045_singapore",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Singapore",
+        "region": "Singapore",
+        "lat": 1.2894114125257872,
+        "lng": 103.85169982910156,
+        "timezone_offset": 7
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T16:09:38.000Z",
+        "departure_utc": "2025-12-24T16:11:38.000Z",
+        "local_arrival_time": "23:10",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Singapore",
+        "duration_seconds": 230,
+        "distance_km": 893,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 43: Da Nang ---",
+      "id": "node_047_thanh_kh__ward",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Da Nang",
+        "region": "Vietnam",
+        "lat": 16.06956823789603,
+        "lng": 108.21224212646486,
+        "timezone_offset": 7
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T16:18:58.000Z",
+        "departure_utc": "2025-12-24T16:19:58.000Z",
+        "local_arrival_time": "23:19",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Da Nang",
+        "duration_seconds": 440,
+        "distance_km": 1712,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 44: Hà Nội ---",
+      "id": "node_146_h__n_i",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Hà Nội",
+        "region": "Vietnam",
+        "lat": 21.022982546427425,
+        "lng": 105.85876464843751,
+        "timezone_offset": 7
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T16:24:55.000Z",
+        "departure_utc": "2025-12-24T16:25:55.000Z",
+        "local_arrival_time": "23:25",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Hà Nội",
+        "duration_seconds": 297,
+        "distance_km": 604,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 7310,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 44: Bangkok ---",
+      "id": "node_046_bangkok",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Bangkok",
+        "region": "Thailand",
+        "lat": 13.748722870755335,
+        "lng": 100.49743652343751,
+        "timezone_offset": 7
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T16:30:09.000Z",
+        "departure_utc": "2025-12-24T16:32:09.000Z",
+        "local_arrival_time": "23:30",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Bangkok",
+        "duration_seconds": 254,
+        "distance_km": 989,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 45: Nay Pyi Taw ---",
+      "id": "node_048_nay_pyi_taw",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Nay Pyi Taw",
+        "region": "Myanmar",
+        "lat": 19.77478067973191,
+        "lng": 96.10633850097656,
+        "timezone_offset": 6.5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T16:35:39.000Z",
+        "departure_utc": "2025-12-24T16:36:39.000Z",
+        "local_arrival_time": "23:06",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Nay Pyi Taw",
+        "duration_seconds": 210,
+        "distance_km": 817,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 46: Thimphu ---",
+      "id": "node_145_thimphu",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Thimphu",
+        "region": "Bhutan",
+        "lat": 27.47263819803909,
+        "lng": 89.63607788085939,
+        "timezone_offset": 6
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T16:41:17.000Z",
+        "departure_utc": "2025-12-24T16:42:17.000Z",
+        "local_arrival_time": "22:41",
+        "time_window_status": "YELLOW"
+      },
+      "transit_to_here": {
+        "description": "Flight to Thimphu",
+        "duration_seconds": 278,
+        "distance_km": 1080,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 46: Dhaka ---",
+      "id": "node_049_dhaka",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Dhaka",
+        "region": "Bangladesh",
+        "lat": 23.762723181676797,
+        "lng": 90.39825439453126,
+        "timezone_offset": 6
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T16:54:34.000Z",
+        "departure_utc": "2025-12-24T16:55:34.000Z",
+        "local_arrival_time": "22:55",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Dhaka",
+        "duration_seconds": 737,
+        "distance_km": 420,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 47: Kolkata ---",
+      "id": "node_054_kolkata",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Kolkata",
+        "region": "India",
+        "lat": 22.56582956966297,
+        "lng": 88.35754394531251,
+        "timezone_offset": 6
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T17:02:49.000Z",
+        "departure_utc": "2025-12-24T17:03:49.000Z",
+        "local_arrival_time": "23:03",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Kolkata",
+        "duration_seconds": 435,
+        "distance_km": 247,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 48: Kathmandu ---",
+      "id": "node_134_kathmandu_metropolit",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Kathmandu",
+        "region": "Nepal",
+        "lat": 27.72243591897343,
+        "lng": 85.31982421875001,
+        "timezone_offset": 5.75
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T17:08:13.000Z",
+        "departure_utc": "2025-12-24T17:09:13.000Z",
+        "local_arrival_time": "22:53",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Kathmandu",
+        "duration_seconds": 264,
+        "distance_km": 650,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 8870,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 50: Colombo ---",
+      "id": "node_144_colombo",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Colombo",
+        "region": "Sri Lanka",
+        "lat": 6.941422561963073,
+        "lng": 79.85687255859376,
+        "timezone_offset": 5.5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T17:19:25.000Z",
+        "departure_utc": "2025-12-24T17:20:25.000Z",
+        "local_arrival_time": "22:49",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Long Haul to Sri Lanka",
+        "duration_seconds": 612,
+        "distance_km": 2381,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 48: Bengaluru ---",
+      "id": "node_055_bengaluru",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Bengaluru",
+        "region": "India",
+        "lat": 12.956382587313202,
+        "lng": 77.59231567382814,
+        "timezone_offset": 5.5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T17:24:18.000Z",
+        "departure_utc": "2025-12-24T17:25:18.000Z",
+        "local_arrival_time": "22:54",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Bengaluru",
+        "duration_seconds": 233,
+        "distance_km": 713,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 11040,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 50: Mumbai ---",
+      "id": "node_135_mumbai",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Mumbai",
+        "region": "India",
+        "lat": 19.059521889847343,
+        "lng": 72.86407470703126,
+        "timezone_offset": 5.5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T17:28:56.000Z",
+        "departure_utc": "2025-12-24T17:29:56.000Z",
+        "local_arrival_time": "22:59",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Mumbai",
+        "duration_seconds": 218,
+        "distance_km": 846,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 51: Surat ---",
+      "id": "node_136_surat",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Surat",
+        "region": "India",
+        "lat": 21.210019282760232,
+        "lng": 72.83660888671876,
+        "timezone_offset": 5.5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T17:36:56.000Z",
+        "departure_utc": "2025-12-24T17:37:56.000Z",
+        "local_arrival_time": "23:07",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Surat",
+        "duration_seconds": 420,
+        "distance_km": 239,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 52: Nagpur ---",
+      "id": "node_140_nagpur",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Nagpur",
+        "region": "India",
+        "lat": 21.148553781704386,
+        "lng": 79.08233642578126,
+        "timezone_offset": 5.5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T17:42:21.000Z",
+        "departure_utc": "2025-12-24T17:43:21.000Z",
+        "local_arrival_time": "23:12",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Nagpur",
+        "duration_seconds": 265,
+        "distance_km": 648,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 8796,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 53: Bhopal ---",
+      "id": "node_137_bhopal",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Bhopal",
+        "region": "India",
+        "lat": 23.25901082664879,
+        "lng": 77.40348815917969,
+        "timezone_offset": 5.5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T17:51:53.000Z",
+        "departure_utc": "2025-12-24T17:52:53.000Z",
+        "local_arrival_time": "23:22",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Bhopal",
+        "duration_seconds": 512,
+        "distance_km": 291,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 49: New Delhi ---",
+      "id": "node_053_new_delhi",
+      "type": "DELIVERY",
+      "location": {
+        "name": "New Delhi",
+        "region": "India",
+        "lat": 28.612856636438657,
+        "lng": 77.20951080322267,
+        "timezone_offset": 5.5
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T17:57:58.000Z",
+        "departure_utc": "2025-12-24T17:59:58.000Z",
+        "local_arrival_time": "23:28",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to New Delhi",
+        "duration_seconds": 305,
+        "distance_km": 596,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 7022,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 55: Hyderabad ---",
+      "id": "node_138_________",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Hyderabad",
+        "region": "Pakistan",
+        "lat": 25.443274612305746,
+        "lng": 68.35693359375001,
+        "timezone_offset": 5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T18:04:01.000Z",
+        "departure_utc": "2025-12-24T18:05:01.000Z",
+        "local_arrival_time": "23:04",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Hyderabad",
+        "duration_seconds": 243,
+        "distance_km": 945,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 50: Islamabad ---",
+      "id": "node_056_islamabad",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Islamabad",
+        "region": "Pakistan",
+        "lat": 33.69178103693052,
+        "lng": 73.0583953857422,
+        "timezone_offset": 5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T18:09:24.000Z",
+        "departure_utc": "2025-12-24T18:10:24.000Z",
+        "local_arrival_time": "23:09",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Islamabad",
+        "duration_seconds": 263,
+        "distance_km": 1023,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 51: Kabul ---",
+      "id": "node_057_kabul",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Kabul",
+        "region": "Afghanistan",
+        "lat": 34.52409575475822,
+        "lng": 69.18434143066408,
+        "timezone_offset": 4.5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T18:21:11.000Z",
+        "departure_utc": "2025-12-24T18:22:11.000Z",
+        "local_arrival_time": "22:51",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Kabul",
+        "duration_seconds": 647,
+        "distance_km": 368,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 52: Tashkent ---",
+      "id": "node_058_tashkent",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Tashkent",
+        "region": "Uzbekistan",
+        "lat": 41.31288691435732,
+        "lng": 69.26330566406251,
+        "timezone_offset": 5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T18:25:49.000Z",
+        "departure_utc": "2025-12-24T18:26:49.000Z",
+        "local_arrival_time": "23:26",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Tashkent",
+        "duration_seconds": 218,
+        "distance_km": 755,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 12461,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 53: Astana ---",
+      "id": "node_059_astana",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Astana",
+        "region": "Kazakhstan",
+        "lat": 51.128091254339836,
+        "lng": 71.43001556396486,
+        "timezone_offset": 5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T18:31:33.000Z",
+        "departure_utc": "2025-12-24T18:32:33.000Z",
+        "local_arrival_time": "23:32",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Astana",
+        "duration_seconds": 284,
+        "distance_km": 1104,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 60: Surgut ---",
+      "id": "node_139_surgut",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Surgut",
+        "region": "Russia",
+        "lat": 61.254386097464504,
+        "lng": 73.38867187500001,
+        "timezone_offset": 5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T18:37:24.000Z",
+        "departure_utc": "2025-12-24T18:38:24.000Z",
+        "local_arrival_time": "23:37",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Surgut",
+        "duration_seconds": 291,
+        "distance_km": 1132,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 54: Moscow ---",
+      "id": "node_060_moscow",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Moscow",
+        "region": "Russia",
+        "lat": 55.7487578359952,
+        "lng": 37.62268066406251,
+        "timezone_offset": 4
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T18:47:33.000Z",
+        "departure_utc": "2025-12-24T18:49:33.000Z",
+        "local_arrival_time": "22:48",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Long Haul to Russia",
+        "duration_seconds": 549,
+        "distance_km": 2136,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 62: Samara ---",
+      "id": "node_141_samara",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Samara",
+        "region": "Russia",
+        "lat": 53.193693006293906,
+        "lng": 50.09902954101563,
+        "timezone_offset": 4
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T18:53:12.000Z",
+        "departure_utc": "2025-12-24T18:54:12.000Z",
+        "local_arrival_time": "22:53",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Samara",
+        "duration_seconds": 219,
+        "distance_km": 853,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 142: Volgograd ---",
+      "id": "node_142_volgograd",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Volgograd",
+        "region": "Russia",
+        "lat": 48.716337032605665,
+        "lng": 44.50286865234375,
+        "timezone_offset": 4
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T18:58:46.000Z",
+        "departure_utc": "2025-12-24T18:59:46.000Z",
+        "local_arrival_time": "22:59",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Volgograd",
+        "duration_seconds": 274,
+        "distance_km": 633,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 8307,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 66: Yerevan ---",
+      "id": "node_143_yerevan",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Yerevan",
+        "region": "Armenia",
+        "lat": 40.17887331434698,
+        "lng": 44.50286865234375,
+        "timezone_offset": 4
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T19:03:50.000Z",
+        "departure_utc": "2025-12-24T19:04:50.000Z",
+        "local_arrival_time": "23:04",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Yerevan",
+        "duration_seconds": 244,
+        "distance_km": 949,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 68: Baku City ---",
+      "id": "node_148_baku_city",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Baku City",
+        "region": "Azerbaijan",
+        "lat": 40.413496049701955,
+        "lng": 49.83398437500001,
+        "timezone_offset": 4.5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T19:17:30.000Z",
+        "departure_utc": "2025-12-24T19:18:30.000Z",
+        "local_arrival_time": "23:48",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Baku City",
+        "duration_seconds": 760,
+        "distance_km": 453,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 2146,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 69: Mashhad ---",
+      "id": "node_147_______________",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Mashhad",
+        "region": "Iran",
+        "lat": 36.38591277287654,
+        "lng": 59.63378906250001,
+        "timezone_offset": 3.5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T19:22:38.000Z",
+        "departure_utc": "2025-12-24T19:23:38.000Z",
+        "local_arrival_time": "22:53",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Mashhad",
+        "duration_seconds": 248,
+        "distance_km": 963,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 55: Tehran ---",
+      "id": "node_062_tehran",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Tehran",
+        "region": "Iran",
+        "lat": 35.67514743608467,
+        "lng": 51.38305664062501,
+        "timezone_offset": 3.5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T19:27:19.000Z",
+        "departure_utc": "2025-12-24T19:28:19.000Z",
+        "local_arrival_time": "22:57",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Tehran",
+        "duration_seconds": 221,
+        "distance_km": 746,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 12153,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 71: Isfahan ---",
+      "id": "node_159_isfahan",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Isfahan",
+        "region": "Iran",
+        "lat": 32.664812573810615,
+        "lng": 51.66320800781251,
+        "timezone_offset": 4
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T19:38:09.000Z",
+        "departure_utc": "2025-12-24T19:39:09.000Z",
+        "local_arrival_time": "23:38",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Isfahan",
+        "duration_seconds": 590,
+        "distance_km": 336,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 56: Baghdad ---",
+      "id": "node_064_baghdad",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Baghdad",
+        "region": "Iraq",
+        "lat": 33.30069061612908,
+        "lng": 44.39300537109376,
+        "timezone_offset": 3
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T19:43:15.000Z",
+        "departure_utc": "2025-12-24T19:44:15.000Z",
+        "local_arrival_time": "22:43",
+        "time_window_status": "YELLOW"
+      },
+      "transit_to_here": {
+        "description": "Flight to Baghdad",
+        "duration_seconds": 246,
+        "distance_km": 682,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 9959,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 57: Kuwait City ---",
+      "id": "node_063_al_nuzha",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Kuwait City",
+        "region": "Kuwait",
+        "lat": 29.33908692734108,
+        "lng": 47.98828125000001,
+        "timezone_offset": 3
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T19:50:06.000Z",
+        "departure_utc": "2025-12-24T19:51:06.000Z",
+        "local_arrival_time": "22:50",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Kuwait City",
+        "duration_seconds": 351,
+        "distance_km": 557,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 5713,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 58: Riyadh ---",
+      "id": "node_065_riyadh",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Riyadh",
+        "region": "Saudi Arabia",
+        "lat": 24.647017162630366,
+        "lng": 46.72485351562501,
+        "timezone_offset": 3
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T19:57:32.000Z",
+        "departure_utc": "2025-12-24T19:59:32.000Z",
+        "local_arrival_time": "22:58",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Riyadh",
+        "duration_seconds": 386,
+        "distance_km": 537,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 5004,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 59: Doha ---",
+      "id": "node_066_doha",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Doha",
+        "region": "Qatar",
+        "lat": 25.279470734081837,
+        "lng": 51.53137207031251,
+        "timezone_offset": 3
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T20:08:10.000Z",
+        "departure_utc": "2025-12-24T20:09:10.000Z",
+        "local_arrival_time": "23:08",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Doha",
+        "duration_seconds": 518,
+        "distance_km": 490,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 3401,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 60: Abu Dhabi ---",
+      "id": "node_067_abu_dhabi",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Abu Dhabi",
+        "region": "United Arab Emirates",
+        "lat": 24.45652548903876,
+        "lng": 54.37614440917969,
+        "timezone_offset": 4
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T20:17:59.000Z",
+        "departure_utc": "2025-12-24T20:18:59.000Z",
+        "local_arrival_time": "00:18",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Abu Dhabi",
+        "duration_seconds": 529,
+        "distance_km": 301,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 61: Dubai ---",
+      "id": "node_093_dubai",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Dubai",
+        "region": "United Arab Emirates",
+        "lat": 25.249664387120884,
+        "lng": 55.31066894531251,
+        "timezone_offset": 4
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T20:22:46.000Z",
+        "departure_utc": "2025-12-24T20:24:46.000Z",
+        "local_arrival_time": "00:23",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Dubai",
+        "duration_seconds": 227,
+        "distance_km": 129,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 62: Muscat ---",
+      "id": "node_068_muscat",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Muscat",
+        "region": "Oman",
+        "lat": 23.61055365511656,
+        "lng": 58.59420776367188,
+        "timezone_offset": 4
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T20:35:52.000Z",
+        "departure_utc": "2025-12-24T20:36:52.000Z",
+        "local_arrival_time": "00:36",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Muscat",
+        "duration_seconds": 666,
+        "distance_km": 379,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 63: Mecca ---",
+      "id": "node_070_makkah_al_mukarramah",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Mecca",
+        "region": "Saudi Arabia",
+        "lat": 21.421111484957944,
+        "lng": 39.82681274414063,
+        "timezone_offset": 3
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T20:45:11.000Z",
+        "departure_utc": "2025-12-24T20:46:11.000Z",
+        "local_arrival_time": "23:45",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Mecca",
+        "duration_seconds": 499,
+        "distance_km": 1942,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 64: Asmara ---",
+      "id": "node_072_asmara",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Asmara",
+        "region": "Eritrea",
+        "lat": 15.337498226968789,
+        "lng": 38.93074035644532,
+        "timezone_offset": 3
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T20:50:17.000Z",
+        "departure_utc": "2025-12-24T20:51:17.000Z",
+        "local_arrival_time": "23:50",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Asmara",
+        "duration_seconds": 246,
+        "distance_km": 683,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 10006,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 65: Addis Ababa ---",
+      "id": "node_071_addis_ababa",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Addis Ababa",
+        "region": "Ethiopia",
+        "lat": 9.033273206791536,
+        "lng": 38.75152587890626,
+        "timezone_offset": 3
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T20:55:15.000Z",
+        "departure_utc": "2025-12-24T20:56:15.000Z",
+        "local_arrival_time": "23:55",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Addis Ababa",
+        "duration_seconds": 238,
+        "distance_km": 701,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 10629,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 66: Kampala ---",
+      "id": "node_073_kampala",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Kampala",
+        "region": "Uganda",
+        "lat": 0.3186018737056562,
+        "lng": 32.58132934570313,
+        "timezone_offset": 3
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T21:01:20.000Z",
+        "departure_utc": "2025-12-24T21:02:20.000Z",
+        "local_arrival_time": "00:01",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Kampala",
+        "duration_seconds": 305,
+        "distance_km": 1186,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 67: Lilongwe ---",
+      "id": "node_075_lilongwe",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Lilongwe",
+        "region": "Malawi",
+        "lat": -13.987376214146455,
+        "lng": 33.76647949218751,
+        "timezone_offset": 2
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T21:09:10.000Z",
+        "departure_utc": "2025-12-24T21:10:10.000Z",
+        "local_arrival_time": "23:09",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Lilongwe",
+        "duration_seconds": 410,
+        "distance_km": 1596,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 68: Beira ---",
+      "id": "node_076_beira",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Beira",
+        "region": "Mozambique",
+        "lat": -19.834135000047684,
+        "lng": 34.83558654785157,
+        "timezone_offset": 2
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T21:14:28.000Z",
+        "departure_utc": "2025-12-24T21:15:28.000Z",
+        "local_arrival_time": "23:14",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Beira",
+        "duration_seconds": 258,
+        "distance_km": 660,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 9220,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 69: Johannesburg ---",
+      "id": "node_077_johannesburg",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Johannesburg",
+        "region": "South Africa",
+        "lat": -26.20103776816127,
+        "lng": 28.03848266601563,
+        "timezone_offset": 2
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T21:19:43.000Z",
+        "departure_utc": "2025-12-24T21:20:43.000Z",
+        "local_arrival_time": "23:20",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Johannesburg",
+        "duration_seconds": 255,
+        "distance_km": 992,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 70: Lubumbashi ---",
+      "id": "node_078_lubumbashi",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Lubumbashi",
+        "region": "Democratic Republic of the Congo",
+        "lat": -11.662996112308035,
+        "lng": 27.48504638671875,
+        "timezone_offset": 2
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T21:27:39.000Z",
+        "departure_utc": "2025-12-24T21:28:39.000Z",
+        "local_arrival_time": "23:28",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Lubumbashi",
+        "duration_seconds": 416,
+        "distance_km": 1618,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 71: Jerusalem ---",
+      "id": "node_084_jerusalem",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Jerusalem",
+        "region": "Israel",
+        "lat": 31.778088097564385,
+        "lng": 35.22560119628907,
+        "timezone_offset": 2
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T21:49:39.000Z",
+        "departure_utc": "2025-12-24T21:51:39.000Z",
+        "local_arrival_time": "23:50",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Long Haul to Israel",
+        "duration_seconds": 1260,
+        "distance_km": 4900,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 3
+      }
+    },
+    {
+      "comment": "--- NODE 72: Damascus ---",
+      "id": "node_086_damascus",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Damascus",
+        "region": "Syria",
+        "lat": 33.50819431588375,
+        "lng": 36.31118774414063,
+        "timezone_offset": 2
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T21:58:01.000Z",
+        "departure_utc": "2025-12-24T21:59:01.000Z",
+        "local_arrival_time": "23:58",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Damascus",
+        "duration_seconds": 382,
+        "distance_km": 218,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 73: Istanbul ---",
+      "id": "node_085_istanbul",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Istanbul",
+        "region": "Turkey",
+        "lat": 41.006070860484314,
+        "lng": 28.975067138671875,
+        "timezone_offset": 2
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T22:03:33.000Z",
+        "departure_utc": "2025-12-24T22:04:33.000Z",
+        "local_arrival_time": "00:04",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Istanbul",
+        "duration_seconds": 272,
+        "distance_km": 1056,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 74: Athens ---",
+      "id": "node_087_athens",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Athens",
+        "region": "Greece",
+        "lat": 37.97884504049713,
+        "lng": 23.7359619140625,
+        "timezone_offset": 2
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T22:10:18.000Z",
+        "departure_utc": "2025-12-24T22:11:18.000Z",
+        "local_arrival_time": "00:10",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Athens",
+        "duration_seconds": 345,
+        "distance_km": 561,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 5855,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 75: Bucharest ---",
+      "id": "node_089_bucharest",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Bucharest",
+        "region": "Romania",
+        "lat": 44.4808302785626,
+        "lng": 26.103515625000004,
+        "timezone_offset": 2
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T22:14:58.000Z",
+        "departure_utc": "2025-12-24T22:15:58.000Z",
+        "local_arrival_time": "00:15",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Bucharest",
+        "duration_seconds": 220,
+        "distance_km": 750,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 12276,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 76: Kyiv ---",
+      "id": "node_088_kyiv",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Kyiv",
+        "region": "Ukraine",
+        "lat": 50.45750402042058,
+        "lng": 30.520019531250004,
+        "timezone_offset": 2
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T22:19:40.000Z",
+        "departure_utc": "2025-12-24T22:20:40.000Z",
+        "local_arrival_time": "00:20",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Kyiv",
+        "duration_seconds": 222,
+        "distance_km": 743,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 12038,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 77: Vilnius ---",
+      "id": "node_091_vilnius",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Vilnius",
+        "region": "Lithuania",
+        "lat": 54.68534347195306,
+        "lng": 25.282287597656254,
+        "timezone_offset": 2
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T22:25:53.000Z",
+        "departure_utc": "2025-12-24T22:26:53.000Z",
+        "local_arrival_time": "00:26",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Vilnius",
+        "duration_seconds": 313,
+        "distance_km": 588,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 6766,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 78: Helsinki ---",
+      "id": "node_091_helsinki",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Helsinki",
+        "region": "Finland",
+        "lat": 60.18523283150752,
+        "lng": 24.927978515625004,
+        "timezone_offset": 2
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T22:31:44.000Z",
+        "departure_utc": "2025-12-24T22:32:44.000Z",
+        "local_arrival_time": "00:32",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Helsinki",
+        "duration_seconds": 291,
+        "distance_km": 612,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 7579,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 79: Stockholm ---",
+      "id": "node_092_stockholm",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Stockholm",
+        "region": "Sweden",
+        "lat": 59.32198054010197,
+        "lng": 18.07113647460938,
+        "timezone_offset": 1
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T22:44:19.000Z",
+        "departure_utc": "2025-12-24T22:45:19.000Z",
+        "local_arrival_time": "23:44",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Stockholm",
+        "duration_seconds": 695,
+        "distance_km": 396,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 80: Warsaw ---",
+      "id": "node_092_warsaw",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Warsaw",
+        "region": "Poland",
+        "lat": 52.24125614966341,
+        "lng": 21.016845703125004,
+        "timezone_offset": 1
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T22:48:47.000Z",
+        "departure_utc": "2025-12-24T22:49:47.000Z",
+        "local_arrival_time": "23:49",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Warsaw",
+        "duration_seconds": 208,
+        "distance_km": 808,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 97: Sarajevo ---",
+      "id": "node_164_sarajevo",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Sarajevo",
+        "region": "Bosnia and Herzegovina",
+        "lat": 43.85656387037451,
+        "lng": 18.41068267822266,
+        "timezone_offset": 1
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T22:53:52.000Z",
+        "departure_utc": "2025-12-24T22:54:52.000Z",
+        "local_arrival_time": "23:54",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Sarajevo",
+        "duration_seconds": 245,
+        "distance_km": 952,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 98: Belgrade ---",
+      "id": "node_154_zemun_urban_municipa",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Belgrade",
+        "region": "Serbia",
+        "lat": 44.84029065139799,
+        "lng": 20.390625000000004,
+        "timezone_offset": 1
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T23:00:29.000Z",
+        "departure_utc": "2025-12-24T23:01:29.000Z",
+        "local_arrival_time": "00:00",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Belgrade",
+        "duration_seconds": 337,
+        "distance_km": 192,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 81: Vienna ---",
+      "id": "node_094_vienna",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Vienna",
+        "region": "Austria",
+        "lat": 48.21735290928554,
+        "lng": 16.364135742187504,
+        "timezone_offset": 1
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T23:10:25.000Z",
+        "departure_utc": "2025-12-24T23:11:25.000Z",
+        "local_arrival_time": "00:10",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Vienna",
+        "duration_seconds": 536,
+        "distance_km": 486,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 3264,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 82: Berlin ---",
+      "id": "node_093_berlin",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Berlin",
+        "region": "Germany",
+        "lat": 52.51622086393074,
+        "lng": 13.392333984375,
+        "timezone_offset": 1
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T23:18:21.000Z",
+        "departure_utc": "2025-12-24T23:20:21.000Z",
+        "local_arrival_time": "00:18",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Berlin",
+        "duration_seconds": 416,
+        "distance_km": 522,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 4519,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 101: Copenhagen ---",
+      "id": "node_152_unknown_location",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Copenhagen",
+        "region": "Denmark",
+        "lat": 55.727110085045986,
+        "lng": 12.48046875,
+        "timezone_offset": 1
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T23:30:57.000Z",
+        "departure_utc": "2025-12-24T23:31:57.000Z",
+        "local_arrival_time": "00:31",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Copenhagen",
+        "duration_seconds": 636,
+        "distance_km": 362,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 102: Hamburg ---",
+      "id": "node_153_hamburg",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Hamburg",
+        "region": "Germany",
+        "lat": 53.56641415275043,
+        "lng": 10.019531250000002,
+        "timezone_offset": 1
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T23:40:22.000Z",
+        "departure_utc": "2025-12-24T23:41:22.000Z",
+        "local_arrival_time": "00:40",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Hamburg",
+        "duration_seconds": 505,
+        "distance_km": 288,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 103: Rotterdam ---",
+      "id": "node_151_rotterdam",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Rotterdam",
+        "region": "Netherlands",
+        "lat": 51.93749209045435,
+        "lng": 4.493408203125001,
+        "timezone_offset": 0
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-24T23:53:28.000Z",
+        "departure_utc": "2025-12-24T23:54:28.000Z",
+        "local_arrival_time": "23:53",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Rotterdam",
+        "duration_seconds": 726,
+        "distance_km": 414,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 83: Luxembourg ---",
+      "id": "node_094_luxembourg",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Luxembourg",
+        "region": "Luxembourg",
+        "lat": 49.608040279767906,
+        "lng": 6.1248779296875,
+        "timezone_offset": 0
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T00:02:45.000Z",
+        "departure_utc": "2025-12-25T00:03:45.000Z",
+        "local_arrival_time": "00:03",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Luxembourg",
+        "duration_seconds": 497,
+        "distance_km": 283,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 105: Frankfurt ---",
+      "id": "node_150_frankfurt",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Frankfurt",
+        "region": "Germany",
+        "lat": 50.12057809796008,
+        "lng": 8.613281250000002,
+        "timezone_offset": 1
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T00:09:14.000Z",
+        "departure_utc": "2025-12-25T00:10:14.000Z",
+        "local_arrival_time": "01:09",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Frankfurt",
+        "duration_seconds": 329,
+        "distance_km": 187,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 106: Munich ---",
+      "id": "node_149_munich",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Munich",
+        "region": "Germany",
+        "lat": 48.13493370228957,
+        "lng": 11.579589843750002,
+        "timezone_offset": 1
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T00:19:16.000Z",
+        "departure_utc": "2025-12-25T00:20:16.000Z",
+        "local_arrival_time": "01:19",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Munich",
+        "duration_seconds": 542,
+        "distance_km": 309,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 107: Milan ---",
+      "id": "node_161_milan",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Milan",
+        "region": "Italy",
+        "lat": 45.460130637921004,
+        "lng": 9.201049804687502,
+        "timezone_offset": 1
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T00:30:27.000Z",
+        "departure_utc": "2025-12-25T00:31:27.000Z",
+        "local_arrival_time": "01:30",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Milan",
+        "duration_seconds": 611,
+        "distance_km": 348,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 88: Rome ---",
+      "id": "node_091_rome",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Rome",
+        "region": "Italy",
+        "lat": 41.88592102814744,
+        "lng": 12.491455078125002,
+        "timezone_offset": 1
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T00:41:03.000Z",
+        "departure_utc": "2025-12-25T00:43:03.000Z",
+        "local_arrival_time": "01:41",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Rome",
+        "duration_seconds": 576,
+        "distance_km": 477,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 2985,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 87: Geneva ---",
+      "id": "node_093_geneva",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Geneva",
+        "region": "Switzerland",
+        "lat": 46.20074541128312,
+        "lng": 6.149597167968751,
+        "timezone_offset": 0
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T00:47:02.000Z",
+        "departure_utc": "2025-12-25T00:48:02.000Z",
+        "local_arrival_time": "00:47",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Geneva",
+        "duration_seconds": 239,
+        "distance_km": 698,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 10501,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 110: Lyon ---",
+      "id": "node_163_lyon",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Lyon",
+        "region": "France",
+        "lat": 45.75219336063106,
+        "lng": 4.812011718750001,
+        "timezone_offset": 0
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T00:51:24.000Z",
+        "departure_utc": "2025-12-25T00:52:24.000Z",
+        "local_arrival_time": "00:51",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Lyon",
+        "duration_seconds": 202,
+        "distance_km": 115,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 86: Paris ---",
+      "id": "node_095_paris",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Paris",
+        "region": "France",
+        "lat": 48.850258199721495,
+        "lng": 2.3455810546875004,
+        "timezone_offset": 0
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T01:03:51.000Z",
+        "departure_utc": "2025-12-25T01:05:51.000Z",
+        "local_arrival_time": "01:04",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Paris",
+        "duration_seconds": 687,
+        "distance_km": 391,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 84: London ---",
+      "id": "node_098_greater_london",
+      "type": "DELIVERY",
+      "location": {
+        "name": "London",
+        "region": "United Kingdom",
+        "lat": 51.50788772102846,
+        "lng": -0.11398315429687501,
+        "timezone_offset": 0
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T01:15:54.000Z",
+        "departure_utc": "2025-12-25T01:17:54.000Z",
+        "local_arrival_time": "01:16",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to London",
+        "duration_seconds": 603,
+        "distance_km": 343,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 113: Manchester ---",
+      "id": "node_158_manchester",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Manchester",
+        "region": "United Kingdom",
+        "lat": 53.494581793167185,
+        "lng": -2.2412109375000004,
+        "timezone_offset": 0
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T01:25:37.000Z",
+        "departure_utc": "2025-12-25T01:26:37.000Z",
+        "local_arrival_time": "01:26",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Manchester",
+        "duration_seconds": 463,
+        "distance_km": 264,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 85: Dublin ---",
+      "id": "node_099_dublin",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Dublin",
+        "region": "Ireland",
+        "lat": 53.370220573956786,
+        "lng": -6.262207031250001,
+        "timezone_offset": 0
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T01:34:25.000Z",
+        "departure_utc": "2025-12-25T01:35:25.000Z",
+        "local_arrival_time": "01:34",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Dublin",
+        "duration_seconds": 468,
+        "distance_km": 267,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 89: Madrid ---",
+      "id": "node_096_madrid",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Madrid",
+        "region": "Spain",
+        "lat": 40.43022363450862,
+        "lng": -3.6914062500000004,
+        "timezone_offset": 0
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T01:41:38.000Z",
+        "departure_utc": "2025-12-25T01:43:38.000Z",
+        "local_arrival_time": "01:42",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Madrid",
+        "duration_seconds": 373,
+        "distance_km": 1452,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 90: Lisbon ---",
+      "id": "node_097_lisbon",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Lisbon",
+        "region": "Portugal",
+        "lat": 38.71766178810086,
+        "lng": -9.136505126953127,
+        "timezone_offset": -1
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T01:51:24.000Z",
+        "departure_utc": "2025-12-25T01:52:24.000Z",
+        "local_arrival_time": "00:51",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Lisbon",
+        "duration_seconds": 466,
+        "distance_km": 504,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 3892,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 91: Dakar ---",
+      "id": "node_100_dakar",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Dakar",
+        "region": "Senegal",
+        "lat": 14.774882506516272,
+        "lng": -17.446289062500004,
+        "timezone_offset": -1
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T02:04:20.000Z",
+        "departure_utc": "2025-12-25T02:05:20.000Z",
+        "local_arrival_time": "01:04",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Long Haul to Senegal",
+        "duration_seconds": 716,
+        "distance_km": 2784,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 118: Conakry ---",
+      "id": "node_164_conakry",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Conakry",
+        "region": "Guinea",
+        "lat": 9.569605202508594,
+        "lng": -13.651885986328127,
+        "timezone_offset": -1
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T02:09:14.000Z",
+        "departure_utc": "2025-12-25T02:10:14.000Z",
+        "local_arrival_time": "01:09",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Conakry",
+        "duration_seconds": 234,
+        "distance_km": 711,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 10948,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 92: Recife ---",
+      "id": "node_093_recife",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Recife",
+        "region": "Brazil",
+        "lat": -8.060585680303934,
+        "lng": -34.8870819935804,
+        "timezone_offset": -3
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T02:23:21.000Z",
+        "departure_utc": "2025-12-25T02:24:21.000Z",
+        "local_arrival_time": "23:23",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Long Haul to Brazil",
+        "duration_seconds": 787,
+        "distance_km": 3062,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 93: Rio de Janeiro ---",
+      "id": "node_093_rio_de_janeiro",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Rio de Janeiro",
+        "region": "Brazil",
+        "lat": -22.905905963507976,
+        "lng": -43.21266174316407,
+        "timezone_offset": -3
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T02:32:23.000Z",
+        "departure_utc": "2025-12-25T02:33:23.000Z",
+        "local_arrival_time": "23:32",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Rio de Janeiro",
+        "duration_seconds": 482,
+        "distance_km": 1875,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 94: São Paulo ---",
+      "id": "node_094_s_o_paulo",
+      "type": "DELIVERY",
+      "location": {
+        "name": "São Paulo",
+        "region": "Brazil",
+        "lat": -23.55737837760718,
+        "lng": -46.63593292236329,
+        "timezone_offset": -3
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T02:43:50.000Z",
+        "departure_utc": "2025-12-25T02:45:50.000Z",
+        "local_arrival_time": "23:44",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to São Paulo",
+        "duration_seconds": 627,
+        "distance_km": 357,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 95: Buenos Aires ---",
+      "id": "node_095_buenos_aires",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Buenos Aires",
+        "region": "Argentina",
+        "lat": -34.60947549180878,
+        "lng": -58.38546752929688,
+        "timezone_offset": -3
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T02:53:01.000Z",
+        "departure_utc": "2025-12-25T02:54:01.000Z",
+        "local_arrival_time": "23:53",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Buenos Aires",
+        "duration_seconds": 431,
+        "distance_km": 1675,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 96: Unknown Location ---",
+      "id": "node_096_unknown_location",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Santiago",
+        "region": "Chile",
+        "lat": -33.44290131937934,
+        "lng": -70.65307617187501,
+        "timezone_offset": -4
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T02:58:53.000Z",
+        "departure_utc": "2025-12-25T02:59:53.000Z",
+        "local_arrival_time": "22:59",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Santiago",
+        "duration_seconds": 292,
+        "distance_km": 1137,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 124: Riberalta ---",
+      "id": "node_165_riberalta",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Riberalta",
+        "region": "Bolivia",
+        "lat": -11.000680786328669,
+        "lng": -66.06920242309572,
+        "timezone_offset": -4
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T03:10:46.000Z",
+        "departure_utc": "2025-12-25T03:11:46.000Z",
+        "local_arrival_time": "23:11",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Long Haul to Bolivia",
+        "duration_seconds": 653,
+        "distance_km": 2539,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 98: Caracas ---",
+      "id": "node_101_caracas",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Caracas",
+        "region": "Venezuela",
+        "lat": 10.501990214686604,
+        "lng": -66.91566467285158,
+        "timezone_offset": -4
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T03:22:01.000Z",
+        "departure_utc": "2025-12-25T03:23:01.000Z",
+        "local_arrival_time": "23:22",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Long Haul to Venezuela",
+        "duration_seconds": 615,
+        "distance_km": 2393,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 126: St. John's ---",
+      "id": "node_160_st__john_s",
+      "type": "DELIVERY",
+      "location": {
+        "name": "St. John's",
+        "region": "Antigua and Barbuda",
+        "lat": 17.117659769677118,
+        "lng": -61.84289932250977,
+        "timezone_offset": -4
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T03:26:57.000Z",
+        "departure_utc": "2025-12-25T03:27:57.000Z",
+        "local_arrival_time": "23:27",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to St. John's",
+        "duration_seconds": 236,
+        "distance_km": 917,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 99: San Juan ---",
+      "id": "node_103_san_juan",
+      "type": "DELIVERY",
+      "location": {
+        "name": "San Juan",
+        "region": "United States",
+        "lat": 18.44704398132657,
+        "lng": -66.07452392578126,
+        "timezone_offset": -4
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T03:38:05.000Z",
+        "departure_utc": "2025-12-25T03:40:05.000Z",
+        "local_arrival_time": "23:38",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to San Juan",
+        "duration_seconds": 608,
+        "distance_km": 472,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 2794,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 128: Santo Domingo ---",
+      "id": "node_166_santo_domingo",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Santo Domingo",
+        "region": "Dominican Republic",
+        "lat": 18.469840182428346,
+        "lng": -69.93415832519533,
+        "timezone_offset": -4
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T03:52:00.000Z",
+        "departure_utc": "2025-12-25T03:53:00.000Z",
+        "local_arrival_time": "23:52",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Santo Domingo",
+        "duration_seconds": 715,
+        "distance_km": 407,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 129: Havana ---",
+      "id": "node_156_havana",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Havana",
+        "region": "Cuba",
+        "lat": 23.150456692453222,
+        "lng": -82.3644886865052,
+        "timezone_offset": -5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T03:58:58.000Z",
+        "departure_utc": "2025-12-25T03:59:58.000Z",
+        "local_arrival_time": "22:59",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Havana",
+        "duration_seconds": 358,
+        "distance_km": 1392,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 130: Nassau ---",
+      "id": "node_167_nassau",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Nassau",
+        "region": "Bahamas",
+        "lat": 25.070361939378042,
+        "lng": -77.34066009521484,
+        "timezone_offset": -5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T04:05:56.000Z",
+        "departure_utc": "2025-12-25T04:06:56.000Z",
+        "local_arrival_time": "23:06",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Nassau",
+        "duration_seconds": 358,
+        "distance_km": 553,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 5557,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 100: Miami ---",
+      "id": "node_106_miami",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Miami",
+        "region": "United States",
+        "lat": 25.77361475337912,
+        "lng": -80.19779205322267,
+        "timezone_offset": -5
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T04:15:38.000Z",
+        "departure_utc": "2025-12-25T04:17:38.000Z",
+        "local_arrival_time": "23:16",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Miami",
+        "duration_seconds": 522,
+        "distance_km": 297,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 101: Orlando ---",
+      "id": "node_107_orlando",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Orlando",
+        "region": "United States",
+        "lat": 28.534464812638436,
+        "lng": -81.38294219970705,
+        "timezone_offset": -5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T04:27:15.000Z",
+        "departure_utc": "2025-12-25T04:28:15.000Z",
+        "local_arrival_time": "23:27",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Orlando",
+        "duration_seconds": 577,
+        "distance_km": 329,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 102: Jacksonville ---",
+      "id": "node_108_jacksonville",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Jacksonville",
+        "region": "United States",
+        "lat": 30.331398006092723,
+        "lng": -81.66893005371095,
+        "timezone_offset": -5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T04:34:09.000Z",
+        "departure_utc": "2025-12-25T04:35:09.000Z",
+        "local_arrival_time": "23:34",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Jacksonville",
+        "duration_seconds": 354,
+        "distance_km": 202,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 103: Tallahassee ---",
+      "id": "node_109_tallahassee",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Tallahassee",
+        "region": "United States",
+        "lat": 30.439202087235607,
+        "lng": -84.28161621093751,
+        "timezone_offset": -5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T04:42:30.000Z",
+        "departure_utc": "2025-12-25T04:43:30.000Z",
+        "local_arrival_time": "23:43",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Tallahassee",
+        "duration_seconds": 441,
+        "distance_km": 251,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 133: Cancún ---",
+      "id": "node_138_canc_n",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Cancún",
+        "region": "Mexico",
+        "lat": 21.186972714123776,
+        "lng": -86.83593750000001,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T04:48:03.000Z",
+        "departure_utc": "2025-12-25T04:49:03.000Z",
+        "local_arrival_time": "22:48",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Cancún",
+        "duration_seconds": 273,
+        "distance_km": 1060,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 136: Chinautla ---",
+      "id": "node_166_chinautla",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Chinautla",
+        "region": "Guatemala",
+        "lat": 14.732386081418454,
+        "lng": -90.48339843750001,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T04:52:32.000Z",
+        "departure_utc": "2025-12-25T04:53:32.000Z",
+        "local_arrival_time": "22:53",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Chinautla",
+        "duration_seconds": 209,
+        "distance_km": 815,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 132: Mexico City ---",
+      "id": "node_137_mexico_city",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Mexico City",
+        "region": "Mexico",
+        "lat": 19.440694401302856,
+        "lng": -99.13513183593751,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T04:58:04.000Z",
+        "departure_utc": "2025-12-25T04:59:04.000Z",
+        "local_arrival_time": "22:58",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Mexico City",
+        "duration_seconds": 272,
+        "distance_km": 1058,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 130: Houston ---",
+      "id": "node_135_houston",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Houston",
+        "region": "United States",
+        "lat": 29.726222319395504,
+        "lng": -95.38330078125001,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T05:04:14.000Z",
+        "departure_utc": "2025-12-25T05:05:14.000Z",
+        "local_arrival_time": "23:04",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Houston",
+        "duration_seconds": 310,
+        "distance_km": 1205,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 129: New Orleans ---",
+      "id": "node_134_new_orleans",
+      "type": "DELIVERY",
+      "location": {
+        "name": "New Orleans",
+        "region": "United States",
+        "lat": 29.973970240516614,
+        "lng": -90.10986328125001,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T05:12:44.000Z",
+        "departure_utc": "2025-12-25T05:13:44.000Z",
+        "local_arrival_time": "23:13",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to New Orleans",
+        "duration_seconds": 450,
+        "distance_km": 509,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 4074,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 127: Jackson ---",
+      "id": "node_132_jackson",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Jackson",
+        "region": "United States",
+        "lat": 32.34284135639302,
+        "lng": -90.17578125000001,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T05:21:27.000Z",
+        "departure_utc": "2025-12-25T05:22:27.000Z",
+        "local_arrival_time": "23:21",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Jackson",
+        "duration_seconds": 463,
+        "distance_km": 263,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 140: Memphis ---",
+      "id": "node_160_memphis",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Memphis",
+        "region": "United States",
+        "lat": 35.15584570226544,
+        "lng": -90.0439453125,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T05:31:37.000Z",
+        "departure_utc": "2025-12-25T05:32:37.000Z",
+        "local_arrival_time": "23:32",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Memphis",
+        "duration_seconds": 550,
+        "distance_km": 313,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 141: Nashville ---",
+      "id": "node_159_nashville",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Nashville",
+        "region": "United States",
+        "lat": 36.2265501474709,
+        "lng": -86.79199218750001,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T05:41:53.000Z",
+        "departure_utc": "2025-12-25T05:42:53.000Z",
+        "local_arrival_time": "23:42",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Nashville",
+        "duration_seconds": 556,
+        "distance_km": 317,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 126: Birmingham ---",
+      "id": "node_131_birmingham",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Birmingham",
+        "region": "United States",
+        "lat": 33.54139466898275,
+        "lng": -86.77001953125001,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T05:51:37.000Z",
+        "departure_utc": "2025-12-25T05:52:37.000Z",
+        "local_arrival_time": "23:52",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Birmingham",
+        "duration_seconds": 524,
+        "distance_km": 299,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 104: Atlanta ---",
+      "id": "node_110_atlanta",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Atlanta",
+        "region": "United States",
+        "lat": 33.75631505992709,
+        "lng": -84.38323974609376,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T05:59:07.000Z",
+        "departure_utc": "2025-12-25T06:00:07.000Z",
+        "local_arrival_time": "23:59",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Atlanta",
+        "duration_seconds": 390,
+        "distance_km": 222,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 105: Columbia ---",
+      "id": "node_111_columbia",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Columbia",
+        "region": "United States",
+        "lat": 33.99119576995599,
+        "lng": -81.04339599609376,
+        "timezone_offset": -5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T06:09:10.000Z",
+        "departure_utc": "2025-12-25T06:10:10.000Z",
+        "local_arrival_time": "01:09",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Columbia",
+        "duration_seconds": 543,
+        "distance_km": 309,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 106: Charlotte ---",
+      "id": "node_112_charlotte",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Charlotte",
+        "region": "United States",
+        "lat": 35.22767235493586,
+        "lng": -80.84289550781251,
+        "timezone_offset": -5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T06:14:14.000Z",
+        "departure_utc": "2025-12-25T06:15:14.000Z",
+        "local_arrival_time": "01:14",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Charlotte",
+        "duration_seconds": 244,
+        "distance_km": 139,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 107: Washington ---",
+      "id": "node_114_washington",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Washington",
+        "region": "United States",
+        "lat": 38.91668153637508,
+        "lng": -77.04711914062501,
+        "timezone_offset": -5
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T06:21:52.000Z",
+        "departure_utc": "2025-12-25T06:23:52.000Z",
+        "local_arrival_time": "01:22",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Washington",
+        "duration_seconds": 398,
+        "distance_km": 531,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 4802,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 108: Philadelphia ---",
+      "id": "node_115_philadelphia",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Philadelphia",
+        "region": "United States",
+        "lat": 39.9602803542957,
+        "lng": -75.15747070312501,
+        "timezone_offset": -5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T06:29:42.000Z",
+        "departure_utc": "2025-12-25T06:30:42.000Z",
+        "local_arrival_time": "01:30",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Philadelphia",
+        "duration_seconds": 350,
+        "distance_km": 199,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 109: New York ---",
+      "id": "node_116_new_york",
+      "type": "DELIVERY",
+      "location": {
+        "name": "New York",
+        "region": "United States",
+        "lat": 40.713955826286046,
+        "lng": -74.00390625000001,
+        "timezone_offset": -5
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T06:34:28.000Z",
+        "departure_utc": "2025-12-25T06:36:28.000Z",
+        "local_arrival_time": "01:34",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to New York",
+        "duration_seconds": 226,
+        "distance_km": 129,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 110: Boston ---",
+      "id": "node_117_boston",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Boston",
+        "region": "United States",
+        "lat": 42.36666166373274,
+        "lng": -71.04858398437501,
+        "timezone_offset": -5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T06:45:27.000Z",
+        "departure_utc": "2025-12-25T06:46:27.000Z",
+        "local_arrival_time": "01:45",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Boston",
+        "duration_seconds": 539,
+        "distance_km": 307,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 111: Quebec ---",
+      "id": "node_121_quebec",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Quebec",
+        "region": "Canada",
+        "lat": 46.81509864599243,
+        "lng": -71.22436523437501,
+        "timezone_offset": -5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T06:54:44.000Z",
+        "departure_utc": "2025-12-25T06:55:44.000Z",
+        "local_arrival_time": "01:55",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Quebec",
+        "duration_seconds": 497,
+        "distance_km": 495,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 3581,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 112: Toronto ---",
+      "id": "node_121_toronto",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Toronto",
+        "region": "Canada",
+        "lat": 43.667871610117494,
+        "lng": -79.376220703125,
+        "timezone_offset": -5
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T06:59:31.000Z",
+        "departure_utc": "2025-12-25T07:01:31.000Z",
+        "local_arrival_time": "02:00",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Toronto",
+        "duration_seconds": 227,
+        "distance_km": 727,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 11520,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 113: Detroit ---",
+      "id": "node_119_detroit",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Detroit",
+        "region": "United States",
+        "lat": 42.32606244456202,
+        "lng": -83.067626953125,
+        "timezone_offset": -5
+      },
+      "stop_experience": {
+        "duration_seconds": 0,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T07:11:20.000Z",
+        "departure_utc": "2025-12-25T07:11:20.000Z",
+        "local_arrival_time": "02:11",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Detroit",
+        "duration_seconds": 589,
+        "distance_km": 335,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 153: Pittsburgh ---",
+      "id": "node_158_pittsburgh",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Pittsburgh",
+        "region": "United States",
+        "lat": 40.43022363450862,
+        "lng": -79.98046875000001,
+        "timezone_offset": -5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T07:21:04.000Z",
+        "departure_utc": "2025-12-25T07:22:04.000Z",
+        "local_arrival_time": "02:21",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Pittsburgh",
+        "duration_seconds": 584,
+        "distance_km": 333,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 114: Indianapolis ---",
+      "id": "node_120_indianapolis",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Indianapolis",
+        "region": "United States",
+        "lat": 39.80009595634841,
+        "lng": -86.15478515625001,
+        "timezone_offset": -5
+      },
+      "stop_experience": {
+        "duration_seconds": 0,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T07:28:44.000Z",
+        "departure_utc": "2025-12-25T07:28:44.000Z",
+        "local_arrival_time": "02:29",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Indianapolis",
+        "duration_seconds": 400,
+        "distance_km": 530,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 4767,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 125: St. Louis ---",
+      "id": "node_130_st__louis",
+      "type": "DELIVERY",
+      "location": {
+        "name": "St. Louis",
+        "region": "United States",
+        "lat": 38.65119833229951,
+        "lng": -90.21972656250001,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T07:39:38.000Z",
+        "departure_utc": "2025-12-25T07:40:38.000Z",
+        "local_arrival_time": "01:40",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to St. Louis",
+        "duration_seconds": 654,
+        "distance_km": 373,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 115: Chicago ---",
+      "id": "node_121_chicago",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Chicago",
+        "region": "United States",
+        "lat": 41.89409955811395,
+        "lng": -87.626953125,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 120,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T07:53:00.000Z",
+        "departure_utc": "2025-12-25T07:55:00.000Z",
+        "local_arrival_time": "01:53",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Chicago",
+        "duration_seconds": 742,
+        "distance_km": 422,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 157: Minneapolis ---",
+      "id": "node_157_minneapolis",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Minneapolis",
+        "region": "United States",
+        "lat": 44.98034238084973,
+        "lng": -93.29864501953126,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T08:00:31.000Z",
+        "departure_utc": "2025-12-25T08:01:31.000Z",
+        "local_arrival_time": "02:01",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Minneapolis",
+        "duration_seconds": 331,
+        "distance_km": 572,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 6216,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 118: Winnipeg ---",
+      "id": "node_122_winnipeg",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Winnipeg",
+        "region": "Canada",
+        "lat": 49.88755653624285,
+        "lng": -97.14111328125001,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T08:06:17.000Z",
+        "departure_utc": "2025-12-25T08:07:17.000Z",
+        "local_arrival_time": "02:06",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Winnipeg",
+        "duration_seconds": 286,
+        "distance_km": 617,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 7761,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 119: Fargo ---",
+      "id": "node_123_fargo",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Fargo",
+        "region": "United States",
+        "lat": 46.86770273172814,
+        "lng": -96.80053710937501,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 0,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T08:17:08.000Z",
+        "departure_utc": "2025-12-25T08:17:08.000Z",
+        "local_arrival_time": "02:17",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Fargo",
+        "duration_seconds": 591,
+        "distance_km": 337,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 120: Sioux Falls ---",
+      "id": "node_124_sioux_falls",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Sioux Falls",
+        "region": "United States",
+        "lat": 43.5565103750476,
+        "lng": -96.7236328125,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 0,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T08:27:55.000Z",
+        "departure_utc": "2025-12-25T08:27:55.000Z",
+        "local_arrival_time": "02:28",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Sioux Falls",
+        "duration_seconds": 647,
+        "distance_km": 368,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 121: Omaha ---",
+      "id": "node_125_omaha",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Omaha",
+        "region": "United States",
+        "lat": 41.261291493919884,
+        "lng": -95.96557617187501,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 0,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T08:35:36.000Z",
+        "departure_utc": "2025-12-25T08:35:36.000Z",
+        "local_arrival_time": "02:36",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Omaha",
+        "duration_seconds": 461,
+        "distance_km": 263,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 122: Kansas City ---",
+      "id": "node_126_kansas_city",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Kansas City",
+        "region": "United States",
+        "lat": 39.104488809440475,
+        "lng": -94.603271484375,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T08:43:24.000Z",
+        "departure_utc": "2025-12-25T08:44:24.000Z",
+        "local_arrival_time": "02:43",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Kansas City",
+        "duration_seconds": 468,
+        "distance_km": 266,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 123: Oklahoma City ---",
+      "id": "node_128_oklahoma_city",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Oklahoma City",
+        "region": "United States",
+        "lat": 35.48751102385376,
+        "lng": -97.53662109375001,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 0,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T08:53:54.000Z",
+        "departure_utc": "2025-12-25T08:53:54.000Z",
+        "local_arrival_time": "02:54",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Oklahoma City",
+        "duration_seconds": 570,
+        "distance_km": 479,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 3025,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 128: Dallas ---",
+      "id": "node_133_dallas",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Dallas",
+        "region": "United States",
+        "lat": 32.7872745269555,
+        "lng": -96.83349609375001,
+        "timezone_offset": -6
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T09:02:53.000Z",
+        "departure_utc": "2025-12-25T09:03:53.000Z",
+        "local_arrival_time": "03:03",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Dallas",
+        "duration_seconds": 539,
+        "distance_km": 307,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 167: Santa Fe ---",
+      "id": "node_167_santa_fe",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Santa Fe",
+        "region": "United States",
+        "lat": 35.71083783530009,
+        "lng": -105.908203125,
+        "timezone_offset": -7
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T09:07:43.000Z",
+        "departure_utc": "2025-12-25T09:08:43.000Z",
+        "local_arrival_time": "02:08",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Santa Fe",
+        "duration_seconds": 230,
+        "distance_km": 895,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 168: Denver ---",
+      "id": "node_168_denver",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Denver",
+        "region": "United States",
+        "lat": 39.774769485295465,
+        "lng": -104.94140625000001,
+        "timezone_offset": -7
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T09:20:17.000Z",
+        "departure_utc": "2025-12-25T09:21:17.000Z",
+        "local_arrival_time": "02:20",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Denver",
+        "duration_seconds": 694,
+        "distance_km": 460,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 2385,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 169: Rapid City ---",
+      "id": "node_169_rapid_city",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Rapid City",
+        "region": "United States",
+        "lat": 44.10336537791152,
+        "lng": -103.22753906250001,
+        "timezone_offset": -7
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T09:29:10.000Z",
+        "departure_utc": "2025-12-25T09:30:10.000Z",
+        "local_arrival_time": "02:29",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Rapid City",
+        "duration_seconds": 473,
+        "distance_km": 502,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 3816,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 170: Calgary ---",
+      "id": "node_170_calgary",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Calgary",
+        "region": "Canada",
+        "lat": 51.055207338584964,
+        "lng": -114.04907226562501,
+        "timezone_offset": -6.5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T09:34:58.000Z",
+        "departure_utc": "2025-12-25T09:35:58.000Z",
+        "local_arrival_time": "03:05",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Calgary",
+        "duration_seconds": 288,
+        "distance_km": 1119,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 171: Salt Lake City ---",
+      "id": "node_171_salt_lake_city",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Salt Lake City",
+        "region": "United States",
+        "lat": 40.78054143186033,
+        "lng": -111.88476562500001,
+        "timezone_offset": -7
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T09:40:55.000Z",
+        "departure_utc": "2025-12-25T09:41:55.000Z",
+        "local_arrival_time": "02:41",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Salt Lake City",
+        "duration_seconds": 297,
+        "distance_km": 1155,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 172: Phoenix ---",
+      "id": "node_172_phoenix",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Phoenix",
+        "region": "United States",
+        "lat": 33.46810795527896,
+        "lng": -112.060546875,
+        "timezone_offset": -7
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T09:45:24.000Z",
+        "departure_utc": "2025-12-25T09:46:24.000Z",
+        "local_arrival_time": "02:45",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Phoenix",
+        "duration_seconds": 209,
+        "distance_km": 813,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 172: Los Angeles ---",
+      "id": "node_173_los_angeles",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Los Angeles",
+        "region": "United States",
+        "lat": 34.048108084909835,
+        "lng": -118.24584960937501,
+        "timezone_offset": -8
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T09:51:51.000Z",
+        "departure_utc": "2025-12-25T09:52:51.000Z",
+        "local_arrival_time": "01:52",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Los Angeles",
+        "duration_seconds": 327,
+        "distance_km": 575,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 6330,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 173: San Francisco ---",
+      "id": "node_174_san_francisco",
+      "type": "DELIVERY",
+      "location": {
+        "name": "San Francisco",
+        "region": "United States",
+        "lat": 37.779398571318765,
+        "lng": -122.43988037109376,
+        "timezone_offset": -8
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T09:58:37.000Z",
+        "departure_utc": "2025-12-25T09:59:37.000Z",
+        "local_arrival_time": "01:59",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to San Francisco",
+        "duration_seconds": 346,
+        "distance_km": 561,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 5838,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 174: Sacramento ---",
+      "id": "node_175_sacramento",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Sacramento",
+        "region": "United States",
+        "lat": 38.56964280859044,
+        "lng": -121.48956298828126,
+        "timezone_offset": -8
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T10:03:09.000Z",
+        "departure_utc": "2025-12-25T10:04:09.000Z",
+        "local_arrival_time": "02:03",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Sacramento",
+        "duration_seconds": 212,
+        "distance_km": 121,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 175: Portland ---",
+      "id": "node_175_portland",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Portland",
+        "region": "United States",
+        "lat": 45.519819502877084,
+        "lng": -122.67574310302736,
+        "timezone_offset": -8
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T10:07:40.000Z",
+        "departure_utc": "2025-12-25T10:08:40.000Z",
+        "local_arrival_time": "02:08",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Portland",
+        "duration_seconds": 211,
+        "distance_km": 779,
+        "speed_curve": "REGIONAL",
+        "speed_kmh": 13282,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 176: Seattle ---",
+      "id": "node_176_seattle",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Seattle",
+        "region": "United States",
+        "lat": 47.60153331738691,
+        "lng": -122.33413696289064,
+        "timezone_offset": -8
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T10:15:29.000Z",
+        "departure_utc": "2025-12-25T10:16:29.000Z",
+        "local_arrival_time": "02:15",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Seattle",
+        "duration_seconds": 409,
+        "distance_km": 233,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 177: Vancouver ---",
+      "id": "node_177_vancouver",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Vancouver",
+        "region": "Canada",
+        "lat": 49.257946402467375,
+        "lng": -123.11210632324219,
+        "timezone_offset": -8
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T10:22:08.000Z",
+        "departure_utc": "2025-12-25T10:23:08.000Z",
+        "local_arrival_time": "02:22",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Vancouver",
+        "duration_seconds": 339,
+        "distance_km": 193,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 178: Juneau ---",
+      "id": "node_178_juneau",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Juneau",
+        "region": "United States",
+        "lat": 58.30182279529629,
+        "lng": -134.41875457763675,
+        "timezone_offset": -9
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T10:28:29.000Z",
+        "departure_utc": "2025-12-25T10:29:29.000Z",
+        "local_arrival_time": "01:28",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Juneau",
+        "duration_seconds": 321,
+        "distance_km": 1247,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 179: Fairbanks ---",
+      "id": "node_179_fairbanks",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Fairbanks",
+        "region": "United States",
+        "lat": 64.83696962687105,
+        "lng": -147.7146148681641,
+        "timezone_offset": -8.5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T10:33:48.000Z",
+        "departure_utc": "2025-12-25T10:34:48.000Z",
+        "local_arrival_time": "02:04",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Fairbanks",
+        "duration_seconds": 259,
+        "distance_km": 1008,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 180: Anchorage ---",
+      "id": "node_180_anchorage",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Anchorage",
+        "region": "United States",
+        "lat": 61.21275048679213,
+        "lng": -149.89334106445315,
+        "timezone_offset": -9
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T10:47:01.000Z",
+        "departure_utc": "2025-12-25T10:48:01.000Z",
+        "local_arrival_time": "01:47",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Anchorage",
+        "duration_seconds": 733,
+        "distance_km": 418,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 181: Kodiak ---",
+      "id": "node_181_kodiak",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Kodiak",
+        "region": "United States",
+        "lat": 57.78934378845171,
+        "lng": -152.40406036376956,
+        "timezone_offset": -8.5
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T10:59:54.000Z",
+        "departure_utc": "2025-12-25T11:00:54.000Z",
+        "local_arrival_time": "02:30",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Kodiak",
+        "duration_seconds": 713,
+        "distance_km": 406,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 182: Papeete ---",
+      "id": "node_184_papeete",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Papeete",
+        "region": "France",
+        "lat": -17.53536817152554,
+        "lng": -149.57061767578128,
+        "timezone_offset": -10
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T11:09:17.000Z",
+        "departure_utc": "2025-12-25T11:10:17.000Z",
+        "local_arrival_time": "01:09",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Long Haul to France",
+        "duration_seconds": 503,
+        "distance_km": 8380,
+        "speed_curve": "HYPERSONIC_LONG",
+        "speed_kmh": 60000,
+        "camera_zoom": 9
+      }
+    },
+    {
+      "comment": "--- NODE 183: Hilo ---",
+      "id": "node_182_hilo",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Hilo",
+        "region": "United States",
+        "lat": 19.711121825769855,
+        "lng": -155.0816345214844,
+        "timezone_offset": -10
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T11:28:13.000Z",
+        "departure_utc": "2025-12-25T11:29:13.000Z",
+        "local_arrival_time": "01:28",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Long Haul to United States",
+        "duration_seconds": 1076,
+        "distance_km": 4185,
+        "speed_curve": "HYPERSONIC",
+        "speed_kmh": 14000,
+        "camera_zoom": 3
+      }
+    },
+    {
+      "comment": "--- NODE 184: Honolulu ---",
+      "id": "node_183_honolulu",
+      "type": "DELIVERY",
+      "location": {
+        "name": "Honolulu",
+        "region": "United States",
+        "lat": 21.302489421557606,
+        "lng": -157.85945892333987,
+        "timezone_offset": -11
+      },
+      "stop_experience": {
+        "duration_seconds": 60,
+        "camera_zoom": 14,
+        "weather_condition": "clear",
+        "presents_delivered_at_stop": 0
+      },
+      "schedule": {
+        "arrival_utc": "2025-12-25T11:39:09.000Z",
+        "departure_utc": "2025-12-25T11:40:09.000Z",
+        "local_arrival_time": "00:39",
+        "time_window_status": "GREEN"
+      },
+      "transit_to_here": {
+        "description": "Flight to Honolulu",
+        "duration_seconds": 596,
+        "distance_km": 339,
+        "speed_curve": "CRUISING",
+        "speed_kmh": 2050,
+        "camera_zoom": 9
+      }
+    }
+  ]
+}

--- a/packages/test-fixtures/src/fixtures.test.ts
+++ b/packages/test-fixtures/src/fixtures.test.ts
@@ -3,6 +3,7 @@ import { fixedClock, CHRISTMAS_EVE_2026 } from './clocks';
 import { createDeterministicRoute } from './routes';
 import { createDeterministicSnapshot } from './snapshots';
 import { SnapshotSchema } from '@santa-tracker/contracts';
+import { legacyAdventFixture, legacyRouteFixture } from './legacy';
 
 describe('@santa-tracker/test-fixtures', () => {
   it('produces deterministic clocks', () => {
@@ -25,5 +26,23 @@ describe('@santa-tracker/test-fixtures', () => {
       expect(arrivals[i]! > arrivals[i - 1]!).toBe(true);
     }
   });
-});
 
+  it('contains the complete validated 2025 route as an immutable fixture', () => {
+    expect(legacyRouteFixture.meta.year).toBe(2025);
+    expect(legacyRouteFixture.route_nodes).toHaveLength(185);
+    expect(legacyRouteFixture.route_nodes[0]?.type).toBe('START');
+    expect(legacyRouteFixture.route_nodes.at(-1)?.location.name).toBe('Honolulu');
+    expect(Object.isFrozen(legacyRouteFixture)).toBe(true);
+    expect(Object.isFrozen(legacyRouteFixture.route_nodes)).toBe(true);
+    expect(Object.isFrozen(legacyRouteFixture.route_nodes[0]?.location)).toBe(true);
+  });
+
+  it('contains all Advent days while keeping payloads available only to day consumers', () => {
+    expect(legacyAdventFixture.days.map(day => day.day)).toEqual(
+      Array.from({ length: 24 }, (_, index) => index + 1),
+    );
+    expect(legacyAdventFixture.days[0]?.payload).toEqual({ text: 'Content for day 1' });
+    expect(Object.isFrozen(legacyAdventFixture.days)).toBe(true);
+    expect(Object.isFrozen(legacyAdventFixture.days[0]?.payload)).toBe(true);
+  });
+});

--- a/packages/test-fixtures/src/fixtures.test.ts
+++ b/packages/test-fixtures/src/fixtures.test.ts
@@ -3,7 +3,19 @@ import { fixedClock, CHRISTMAS_EVE_2026 } from './clocks';
 import { createDeterministicRoute } from './routes';
 import { createDeterministicSnapshot } from './snapshots';
 import { SnapshotSchema } from '@santa-tracker/contracts';
-import { legacyAdventFixture, legacyRouteFixture } from './legacy';
+import { LEGACY_SOURCE_SHA256, legacyAdventFixture, legacyRouteFixture } from './legacy';
+
+function isObjectLike(value: unknown): value is object {
+  return value !== null && typeof value === 'object';
+}
+
+function expectDeeplyFrozen(value: unknown, seen = new Set<object>()): void {
+  if (!isObjectLike(value)) return;
+  if (seen.has(value)) return;
+  seen.add(value);
+  expect(Object.isFrozen(value)).toBe(true);
+  for (const child of Object.values(value)) expectDeeplyFrozen(child, seen);
+}
 
 describe('@santa-tracker/test-fixtures', () => {
   it('produces deterministic clocks', () => {
@@ -32,9 +44,8 @@ describe('@santa-tracker/test-fixtures', () => {
     expect(legacyRouteFixture.route_nodes).toHaveLength(185);
     expect(legacyRouteFixture.route_nodes[0]?.type).toBe('START');
     expect(legacyRouteFixture.route_nodes.at(-1)?.location.name).toBe('Honolulu');
-    expect(Object.isFrozen(legacyRouteFixture)).toBe(true);
-    expect(Object.isFrozen(legacyRouteFixture.route_nodes)).toBe(true);
-    expect(Object.isFrozen(legacyRouteFixture.route_nodes[0]?.location)).toBe(true);
+    expect(LEGACY_SOURCE_SHA256.route).toBe('25a3222d49daf14726ece485d00684f47013099a730cac5927b47be40ab22917');
+    expectDeeplyFrozen(legacyRouteFixture);
   });
 
   it('contains all Advent days while keeping payloads available only to day consumers', () => {
@@ -42,7 +53,7 @@ describe('@santa-tracker/test-fixtures', () => {
       Array.from({ length: 24 }, (_, index) => index + 1),
     );
     expect(legacyAdventFixture.days[0]?.payload).toEqual({ text: 'Content for day 1' });
-    expect(Object.isFrozen(legacyAdventFixture.days)).toBe(true);
-    expect(Object.isFrozen(legacyAdventFixture.days[0]?.payload)).toBe(true);
+    expect(LEGACY_SOURCE_SHA256.advent).toBe('b8e8212cc75d3bca0a110756fde7f8a10b213f1efec35fa3214a9e394552be2f');
+    expectDeeplyFrozen(legacyAdventFixture);
   });
 });

--- a/packages/test-fixtures/src/index.ts
+++ b/packages/test-fixtures/src/index.ts
@@ -1,4 +1,4 @@
 export * from './clocks';
 export * from './routes';
 export * from './snapshots';
-
+export * from './legacy';

--- a/packages/test-fixtures/src/legacy.ts
+++ b/packages/test-fixtures/src/legacy.ts
@@ -20,6 +20,12 @@ function deepFreeze<T>(value: T): T {
   return value;
 }
 
+/** SHA-256 values of the source files copied into these fixtures. */
+export const LEGACY_SOURCE_SHA256 = {
+  route: '25a3222d49daf14726ece485d00684f47013099a730cac5927b47be40ab22917',
+  advent: 'b8e8212cc75d3bca0a110756fde7f8a10b213f1efec35fa3214a9e394552be2f',
+} as const;
+
 /** The unmodified 2025 route, checked once before test code can use it. */
 export const legacyRouteFixture: Readonly<LegacyRouteFixture> = deepFreeze(
   LegacyRouteFixtureSchema.parse(routeSource),
@@ -29,11 +35,3 @@ export const legacyRouteFixture: Readonly<LegacyRouteFixture> = deepFreeze(
 export const legacyAdventFixture: Readonly<LegacyAdventFixture> = deepFreeze(
   LegacyAdventFixtureSchema.parse(adventCalendarSource),
 );
-
-export function getLegacyRouteFixture(): Readonly<LegacyRouteFixture> {
-  return legacyRouteFixture;
-}
-
-export function getLegacyAdventFixture(): Readonly<LegacyAdventFixture> {
-  return legacyAdventFixture;
-}

--- a/packages/test-fixtures/src/legacy.ts
+++ b/packages/test-fixtures/src/legacy.ts
@@ -7,11 +7,16 @@ import {
 import adventCalendarSource from './data/advent-calendar-2024.json';
 import routeSource from './data/santa-route-2025.json';
 
+function isObjectLike(value: unknown): value is object {
+  return value !== null && typeof value === 'object';
+}
+
 function deepFreeze<T>(value: T): T {
-  if (value !== null && typeof value === 'object' && !Object.isFrozen(value)) {
-    Object.freeze(value);
-    for (const child of Object.values(value)) deepFreeze(child);
-  }
+  if (!isObjectLike(value)) return value;
+  if (Object.isFrozen(value)) return value;
+
+  Object.freeze(value);
+  for (const child of Object.values(value)) deepFreeze(child);
   return value;
 }
 

--- a/packages/test-fixtures/src/legacy.ts
+++ b/packages/test-fixtures/src/legacy.ts
@@ -1,0 +1,34 @@
+import {
+  LegacyAdventFixtureSchema,
+  LegacyRouteFixtureSchema,
+  type LegacyAdventFixture,
+  type LegacyRouteFixture,
+} from '@santa-tracker/contracts';
+import adventCalendarSource from './data/advent-calendar-2024.json';
+import routeSource from './data/santa-route-2025.json';
+
+function deepFreeze<T>(value: T): T {
+  if (value !== null && typeof value === 'object' && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const child of Object.values(value)) deepFreeze(child);
+  }
+  return value;
+}
+
+/** The unmodified 2025 route, checked once before test code can use it. */
+export const legacyRouteFixture: Readonly<LegacyRouteFixture> = deepFreeze(
+  LegacyRouteFixtureSchema.parse(routeSource),
+);
+
+/** The unmodified Advent manifest, checked once before test code can use it. */
+export const legacyAdventFixture: Readonly<LegacyAdventFixture> = deepFreeze(
+  LegacyAdventFixtureSchema.parse(adventCalendarSource),
+);
+
+export function getLegacyRouteFixture(): Readonly<LegacyRouteFixture> {
+  return legacyRouteFixture;
+}
+
+export function getLegacyAdventFixture(): Readonly<LegacyAdventFixture> {
+  return legacyAdventFixture;
+}


### PR DESCRIPTION
## Summary

- add shared validation schemas for the legacy route and Advent fixture shapes
- migrate all 185 route nodes and 24 Advent days into deeply frozen test fixtures
- remove the Next.js fallback to retired Flask data paths
- add fixture parity and immutability tests

Closes #218

## Validation

- `pnpm test` (45 passed, 2 database tests skipped without `DATABASE_URL_TEST`)
- targeted ESLint for changed files
- `pnpm exec tsc --noEmit -p packages/contracts/tsconfig.json`
- `pnpm exec tsc --noEmit -p packages/test-fixtures/tsconfig.json`
- `pnpm --filter web build`

The shared worktree contained unrelated, untracked Storybook changes under `packages/ui`, so aggregate typecheck/lint/build commands were not used as evidence for this PR. They are not included in the commit.